### PR TITLE
Handle absolute repo paths and include .py packages in path detection

### DIFF
--- a/Utils/yOCTImportPythonModule.m
+++ b/Utils/yOCTImportPythonModule.m
@@ -80,7 +80,14 @@ pyexe = char(pe.Executable);
 if isempty(in.repoName)
     repoBase = pwd;
 else
-    repoBase = fullfile(pwd, char(in.repoName));
+    % Check if repoName is already an absolute path
+    if isfolder(char(in.repoName))
+        % It's an absolute path, use it directly
+        repoBase = char(in.repoName);
+    else
+        % It's a relative name, append to pwd
+        repoBase = fullfile(pwd, char(in.repoName));
+    end
 end
 candidates = string({repoBase, fullfile(repoBase,'src')});
 parts  = split(string(in.packageName), '.');   % top-level package name
@@ -95,7 +102,8 @@ existing = string(cellfun(@char, cell(py.list(pypath)), 'UniformOutput', false))
 
 added = false;
 for c = candidates
-    if isfolder(fullfile(char(c), char(topPkg)))
+    % Check if package exists as folder OR as .py file
+    if isfolder(fullfile(char(c), char(topPkg))) || isfile(fullfile(char(c), char(topPkg) + ".py"))
         if ~any(existing == c)
             if in.v, fprintf('[Bridge] Adding to sys.path: %s\n', char(c)); end
             % Call the Python list.insert(...) method


### PR DESCRIPTION
♻️ Current Situation & Problem
The function assumed all repoName inputs were relative paths and only detected packages implemented as folders.
This caused incorrect path resolutions when using absolute paths and missed Python packages distributed as single .py files.

⚙️ Release Notes:
	•	✅ Added logic to handle both absolute and relative repoName inputs.
	•	🧩 Updated repoBase assignment to check with isfolder() before appending pwd.
	•	📦 Extended package detection to include .py files alongside folders.
	•	📝 Improved comments and readability of path-handling logic.

📚 Documentation
Inline comments added to clarify absolute vs relative path handling and .py detection behavior.

✅ Testing
	•	Verified correct handling for both relative and absolute repo paths.
	•	Confirmed .py package files are correctly added to sys.path.
	•	No regression found in previous path detection behavior.

This updates adds compatibility with current new OCT system setup.