### PR TITLE
Fix scan function signature

### DIFF
--- a/ThorlabsImager/yOCTScanTile.m
+++ b/ThorlabsImager/yOCTScanTile.m
@@ -1,3 +1,4 @@
+function [json] = yOCTScanTile(varargin)
 % This function preforms an OCT Scan of a volume, and them tile around to
 % stitch together multiple scans. Tiling will be done by 3D translation
 % stage.


### PR DESCRIPTION
yOCTScanTile lost it's signature during previous commits and needs it in order to work without errors