### PR TITLE
Fix: Write combined BigTIFF directly to output drive instead of system temp

### DIFF
--- a/LoadSave/yOCT2Tif.m
+++ b/LoadSave/yOCT2Tif.m
@@ -349,7 +349,15 @@ else
     % This keeps memory usage at 1 slide instead of N slides.
     if isOutputFile
         metaJson = buildTiffVolumeMetadata(metadata, c);
-        tn = [tempname '.tif'];
+
+        % For local paths, write directly to the output to avoid filling
+        % the system temp drive with a multi GB BigTIFF.
+        % For AWS, write to a temp file first then upload.
+        if isAWS
+            tn = [tempname '.tif'];
+        else
+            tn = outputFilePaths{1};
+        end
         t = Tiff(tn, 'w8');  % BigTIFF to support files > 4 GB
 
         for frameI = 1:numberOfYPlanes
@@ -368,9 +376,11 @@ else
         end
         t.close();
 
-        % Copy the assembled file to the final output destination
-        awsCopyFileFolder(tn, outputFilePaths{1});
-        delete(tn);
+        % For AWS, copy the assembled file to the final destination
+        if isAWS
+            awsCopyFileFolder(tn, outputFilePaths{1});
+            delete(tn);
+        end
     end
     
     % If output folder is not required, delete it


### PR DESCRIPTION
**Problem**

When finalizing a tiled scan (partialFileMode=3), the assembled BigTIFF was written to tempname (the system temp directory, typically C:\...\AppData\Local\Temp\) and then copied to the final destination (like our SSD or hard drive. H:\...).

For large scans (40x, multi GB volumes), the combined file can easily exceed the available space on C:. When C: runs out of space, tifflib fails when trying to write the first strip:

```
Error using tifflib
Unable to write strip #1
```

The destination drive (H:) has enough space, but the code never used it because it tried to build the full file on C: first.


**Solution**

For local paths, write the BigTIFF directly to outputFilePaths{1} (the destination drive), eliminating the intermediate write to tempname. tempname is still used for AWS paths, where a local file is needed before uploading.

This:

- Removes the system drive space requirement
- Avoids a redundant multi GB copy for local paths
- Leaves the AWS code path unchanged