### PR TITLE
Enable MATLAB setup caching to reduce CI setup time

### DIFF
--- a/.github/workflows/matlab-tests.yml
+++ b/.github/workflows/matlab-tests.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
+          release: R2024a
+          cache: true
           products: Signal_Processing_Toolbox Image_Processing_Toolbox Statistics_and_Machine_Learning_Toolbox Parallel_Computing_Toolbox
 
       - name: Run yOCTTestAll


### PR DESCRIPTION
**Problem:** The CI workflow installs MATLAB and all required toolboxes from scratch on every pull request run, adding ~3-2 minutes of setup time. The setup-matlab action supports built-in caching, but it was not enabled.

**Solution**: 
Added cache: true and pinned release: R2024a to the matlab-actions/setup-matlab step, following the same pattern already approved in the collect-virtual-histology-samples repo. 
After the first run, subsequent CI runs reuse the cached MATLAB installation, reducing setup time.