### PR TITLE
Add probe calibration file for 20x Olympus lens on OCTG system

### DIFF
--- a/ThorlabsImager/Probe Olympus - 20x - OCTG.ini
+++ b/ThorlabsImager/Probe Olympus - 20x - OCTG.ini
@@ -1,0 +1,63 @@
+## This file defines OCT Probe including OCT Scanning head & lens
+## It includes data used by Thorlabs OCT Software as well as myOCT package
+
+ObjectiveName = 'Olympus20xGan632'
+
+# Working distance, to protect from crashing probe against sample, mm
+# Used by myOCT library but not thorlabs
+ObjectiveWorkingDistance = 3.5
+
+## Converting from voltage to phyisical position of the beam
+## Parameters here are calibrated for steady state beam, meaning if the beam
+## is at rest (slow axis), what position will it take based on the motor voltage?
+
+# Linear factor for x,y axis in volts/mm
+FactorX = -2.747
+FactorY = 2.747
+# Offset in volts
+OffsetX = 0
+OffsetY = 0.186
+
+## Dinamic scan adjustments, when scannig along x axis (fast scan), voltage introduces
+## deviations from the FactorX and OffsetX above. Used by myOCT package, not  Thorlabs
+
+# The following was calibrated for 1mm scan, 1000 A Scans during the scan, no AScan/BScan Averaging
+
+# Linear factor (no units), if DynamicFactorX>1 it means we need to scan more than the distance we 
+# intended to get the same resolution in mm
+DynamicFactorX = 1.00
+
+# Offset in mm
+DynamicOffsetX = -0.0018
+
+## Field of View Defenitions, in mm
+RangeMaxX = 20
+RangeMaxY = 20
+
+## Image corrections in post processing (used by myOCT library only, not used by Thorlabs)
+
+# Default dispersion parameter used by this lens, units unknown, the same as myOCT units
+DefaultDispersionQuadraticTerm = 8.6883e+07
+
+# Optical path correction polynomial, to correct for appered bending.
+# The following polynomial describes by how much image moved along z axis (in microns)
+# As a function of pixel's position (in microns)
+# given pixel position x,y correction is to move z by -(p(1)*x + p(2)*y + p(3)*x^2 + p(4)*y^2 + p(5)*x*y)
+OpticalPathCorrectionPolynomial = [0.0075237, 0.012723, -0.00015741, -0.00022652, 5.716e-11]
+
+## Apodization
+# Position (along x axis) used for apodization, voltage
+ApoVoltage = 10.0
+# Time for the scanner to get from an apodization position to scan position and vice versa in seconds
+FlybackTime = 0.002
+
+## Camera overlay compared to OCT probe
+## Calibrates camera's position with respect to the laser
+# Linear factor for x,y axis in pixels/mm
+CameraScalingX = 192
+CameraScalingY = 192
+# Offset in pixels
+CameraOffsetX = 332
+CameraOffsetY = 242
+# Angle between coordinate system of the laser and video camera (deg)
+CameraAngle = 90.0


### PR DESCRIPTION
**Problem**
The 20x Olympus lens on the Gan632 (OCTG) system had no probe .ini calibration file in the myOCT library. Calling yOCTGetProbeIniPath('20x', 'OCTG') would throw a "Probe file not found" error, blocking any scan or processing workflow using this lens/system combination.

**Solution**
Added **Probe Olympus - 20x - OCTG.ini** to ThorlabsImager, following the existing naming convention. The file includes:

- Calibrated voltage-to-position calibration factors for the galvo scanners (X/Y)
- Calibrated dynamic scan correction for fast-axis deviation
- Default dispersion quadratic term for this lens
- Optical path correction polynomial to remove field curvature/distortion
- Camera overlay calibration for laser-to-camera alignment

Here's the distortion figure:
<img width="1579" height="888" alt="Screenshot 2026-04-23 at 1 12 52 AM" src="https://github.com/user-attachments/assets/33ab22bb-53ed-4e52-a67a-a25ef8832b73" />
