### PR TITLE
Add safe stop/resume to yOCTProcessTiledScan

### DIFF
--- a/LoadSave/yOCT2Tif.m
+++ b/LoadSave/yOCT2Tif.m
@@ -275,6 +275,12 @@ elseif mode == 2
             continue;
         end
 
+        % If a partial .tif exists without its .json (half-committed), delete it so
+        % awsCopyFile_MW1 can create its staging subdirectory at that path
+        if in.resume && awsExist(p,'file')
+            delete(p);
+        end
+
         bits = yOCT2Tif_ConvertBitsData(data(:,:,yI),c,false);
         
         % Save Tif stack file

--- a/LoadSave/yOCT2Tif.m
+++ b/LoadSave/yOCT2Tif.m
@@ -278,7 +278,7 @@ elseif mode == 2
         % If a partial .tif exists without its .json (half-committed), delete it so
         % awsCopyFile_MW1 can create its staging subdirectory at that path
         if in.resume && awsExist(p,'file')
-            delete(p);
+            awsRmFile(p);
         end
 
         bits = yOCT2Tif_ConvertBitsData(data(:,:,yI),c,false);

--- a/LoadSave/yOCT2Tif.m
+++ b/LoadSave/yOCT2Tif.m
@@ -233,6 +233,10 @@ elseif mode == 1
             catch
                 % No staged artifacts to commit, or commit already done. Safe to ignore.
             end
+            % If MATLAB died after Mode 1 created the directory but before it finished
+            % writing inside it, a leftover directory named y####.tif/ remains.
+            % Remove those so mode 2 can re-write those frames cleanly.
+            yOCT2Tif_cleanOrphanStages(outputFilePaths{3});
         else
             % Make sure the partial folder exists for the upcoming mode 2 writes
             if ~awsIsAWSPath(outputFilePaths{3}) && ~exist(outputFilePaths{3},'dir')
@@ -281,6 +285,12 @@ elseif mode == 2
             awsRmFile(p);
         end
 
+        % If an orphan staging directory exists because Mode 1 was interrupted before
+        % writing .getmeout inside the uuid subfolder, nuke it so Mode 1 can start it fresh.
+        if in.resume && awsExist(p,'dir')
+            awsRmDir(p);
+        end
+
         bits = yOCT2Tif_ConvertBitsData(data(:,:,yI),c,false);
         
         % Save Tif stack file
@@ -319,7 +329,26 @@ else
     %   6. Remove partialMode only after the above are guaranteed on disk.
     
     % Step 1: commit anything left staged by MW1 in partialMode.
-    awsCopyFile_MW2(outputFilePaths{3});
+    try
+        awsCopyFile_MW2(outputFilePaths{3});
+    catch
+        % No staged artifacts (full resume with no new work). Safe to skip.
+    end
+
+    % Step 1b: Clean up the output folder from a previous interrupted run.
+    % Step 3 below also writes slides via Mode 1 (into the output folder). If MATLAB
+    % died mid-write, the output folder may contain y####.tif/ directories instead
+    % of y####.tif files. Mode 2 promotes any that finished writing; cleanOrphanStages
+    % removes the rest. Without this, Step 5 (BigTIFF build) would crash when
+    % imageDatastore encounters a directory where it expects a TIFF file.
+    if in.resume && awsExist(outputFilePaths{2},'dir')
+        try
+            awsCopyFile_MW2(outputFilePaths{2});
+        catch
+            % no staged artifacts here, safe to skip
+        end
+        yOCT2Tif_cleanOrphanStages(outputFilePaths{2});
+    end
 
     % Step 2: Resolve clim; reuse _clim.json if present so results are deterministic
     climCachePath = awsModifyPathForCompetability( ...
@@ -429,7 +458,11 @@ else
     end
 
     % Commit rewritten slides
-    awsCopyFile_MW2(outputFilePaths{2});
+    try
+        awsCopyFile_MW2(outputFilePaths{2});
+    catch
+        % No staged artifacts (full resume with all slides already committed).
+    end
 
     % Step 4: Write TifMetadata.json atomically
     metaJson = buildTiffVolumeMetadata(metadata,c);
@@ -565,4 +598,68 @@ else
     tagstruct.YResolution      = 1;
     tagstruct.ResolutionUnit   = Tiff.ResolutionUnit.None;
     tagstruct.ImageDescription = sprintf('ImageJ=1.53\nspacing=1.00\nimages=%d\n', totalFrames);
+end
+
+function yOCT2Tif_cleanOrphanStages(partialFolder)
+% Remove orphan staging directories left by an interrupted MW1 write.
+% After a clean stage, MW2 promotes the contents into a FILE named y####.tif
+% (or y####.tif.json). Anything still present as a DIRECTORY matching that
+% pattern means MW1 crashed before writing its .getmeout marker, so MW2 had
+% nothing to promote. We delete those dirs so the next parfor iteration
+% re-stages from scratch.
+
+fprintf('%s yOCT2Tif resume: scanning for orphan staging dirs in %s\n', ...
+    datestr(datetime), partialFolder);
+removed = {};
+failed = {};
+
+if awsIsAWSPath(partialFolder)
+    entries = awsls(partialFolder);
+    for k = 1:numel(entries)
+        name = entries{k};
+        % awsls returns folder entries with a trailing '/'; strip it for regex.
+        if endsWith(name,'/')
+            stripped = name(1:end-1);
+        else
+            continue; % not a directory, cannot be orphan stage
+        end
+        if ~isempty(regexp(stripped,'^y\d+\.tif(\.json)?$','once'))
+            target = [partialFolder '/' stripped];
+            try
+                awsRmDir(target);
+                removed{end+1} = stripped; %#ok<AGROW>
+            catch err
+                failed{end+1} = sprintf('%s (%s)', stripped, err.message); %#ok<AGROW>
+            end
+        end
+    end
+else
+    listing = dir(partialFolder);
+    for k = 1:numel(listing)
+        if ~listing(k).isdir; continue; end
+        name = listing(k).name;
+        if strcmp(name,'.') || strcmp(name,'..'); continue; end
+        if ~isempty(regexp(name,'^y\d+\.tif(\.json)?$','once'))
+            target = fullfile(partialFolder,name);
+            try
+                rmdir(target,'s');
+                removed{end+1} = name; %#ok<AGROW>
+            catch err
+                failed{end+1} = sprintf('%s (%s)', name, err.message); %#ok<AGROW>
+            end
+        end
+    end
+end
+
+if isempty(removed) && isempty(failed)
+    fprintf('%s yOCT2Tif resume: no orphan staging dirs found.\n', datestr(datetime));
+else
+    if ~isempty(removed)
+        fprintf('%s yOCT2Tif resume: removed %d orphan staging dir(s): %s\n', ...
+            datestr(datetime), numel(removed), strjoin(removed, ', '));
+    end
+    if ~isempty(failed)
+        fprintf(2,'%s yOCT2Tif resume: FAILED to remove %d orphan dir(s): %s\n', ...
+            datestr(datetime), numel(failed), strjoin(failed, ' | '));
+    end
 end

--- a/LoadSave/yOCT2Tif.m
+++ b/LoadSave/yOCT2Tif.m
@@ -61,6 +61,8 @@ addParameter(p,'clim',[])
 addParameter(p,'metadata',[])
 addParameter(p,'partialFileMode',0);
 addParameter(p,'partialFileModeIndex',[]);
+% If true, skip slides already committed and reuse saved clim (safe stop/resume)
+addParameter(p,'resume',false,@islogical);
 
 parse(p,varargin{:});
 in = p.Results;
@@ -223,19 +225,35 @@ if mode == 0
 %% Actual writing of data, partial file mode (initialization)
 elseif mode == 1
     
-    % If output a file, clear it before writing
-    if awsExist(outputFilePaths{1},'file') && isOutputFile
-        awsRmFile(outputFilePaths{1}); %Clear file
-    end
+    if in.resume
+        % Resume mode: preserve existing partial/output data.
+        if awsExist(outputFilePaths{3},'dir')
+            try
+                awsCopyFile_MW2(outputFilePaths{3});
+            catch
+                % No staged artifacts to commit, or commit already done. Safe to ignore.
+            end
+        else
+            % Make sure the partial folder exists for the upcoming mode 2 writes
+            if ~awsIsAWSPath(outputFilePaths{3}) && ~exist(outputFilePaths{3},'dir')
+                mkdir(outputFilePaths{3});
+            end
+        end
+    else
+        % If output a file, clear it before writing
+        if awsExist(outputFilePaths{1},'file') && isOutputFile
+            awsRmFile(outputFilePaths{1}); %Clear file
+        end
 
-    % Always outputing a folder, clear it
-    if awsExist(outputFilePaths{2},'dir')
-        awsRmDir(outputFilePaths{2}); %Clear dir
-    end
-    
-    % Clear the temporary folder as well
-    if awsExist(outputFilePaths{3},'dir')
-        awsRmDir(outputFilePaths{3});
+        % Always outputing a folder, clear it
+        if awsExist(outputFilePaths{2},'dir')
+            awsRmDir(outputFilePaths{2}); %Clear dir
+        end
+        
+        % Clear the temporary folder as well
+        if awsExist(outputFilePaths{3},'dir')
+            awsRmDir(outputFilePaths{3});
+        end
     end
     
     % Files should be in the folder
@@ -250,9 +268,14 @@ elseif mode == 2
     end
     
     for yI=1:size(data,3)
-        bits = yOCT2Tif_ConvertBitsData(data(:,:,yI),c,false);
-        
         p = yScanPath(outputFilePaths{3},in.partialFileModeIndex(yI));
+
+        % Skip frames already saved by a previous run (.json presence = complete)
+        if in.resume && awsExist([p '.json'],'file') && awsExist(p,'file')
+            continue;
+        end
+
+        bits = yOCT2Tif_ConvertBitsData(data(:,:,yI),c,false);
         
         % Save Tif stack file
         tn1 = [tempname '.tif'];
@@ -260,7 +283,7 @@ elseif mode == 2
         awsCopyFile_MW1(tn1,p); ...
         delete(tn1); % Cleanup   
     
-        % Save C as a temp json
+        % Save C as a temp json (written last: acts as the completion marker)
         tn2 = [tempname '.json'];
         a.c = c;
         awsWriteJSON(a,tn2);
@@ -273,8 +296,40 @@ elseif mode == 2
     
 %% Actual writing of data, partial file mode (finalization part)
 else
-    % Finish WM work
+    % Resume: The goal of this block is that every artifact produced here is either
+    % fully committed under its final name or absent. We NEVER leave behind a
+    % half-written file sharing the final name: an interrupted write stays
+    % under an .inProgress sibling name (or as MW1-staged .getmeout folders)
+    % so that a subsequent resume can redo only the steps that did not complete.
+    % Order of operations:
+    %   1. Commit MW1 staging in partialMode.
+    %   2. Resolve/persist a stable global clim via _clim.json in partialMode.
+    %      This prevents the clim used for rewriting slides from changing between
+    %      runs, which would otherwise produce a different final BigTIFF.
+    %   3. Rewrite each slide to the output folder, skipping slides whose final
+    %      name already exists (they were committed by a prior run).
+    %   4. Write TifMetadata.json atomically.
+    %   5. Build BigTIFF into an .inProgress sibling, then rename to final name once complete.
+    %   6. Remove partialMode only after the above are guaranteed on disk.
+    
+    % Step 1: commit anything left staged by MW1 in partialMode.
     awsCopyFile_MW2(outputFilePaths{3});
+
+    % Step 2: Resolve clim; reuse _clim.json if present so results are deterministic
+    climCachePath = awsModifyPathForCompetability( ...
+        [outputFilePaths{3} '/_clim.json']);
+    cachedClim = [];
+    if in.resume && awsExist(climCachePath,'file')
+        try
+            climStruct = awsReadJSON(climCachePath);
+            if isfield(climStruct,'c') && numel(climStruct.c) == 2
+                cachedClim = climStruct.c;
+            end
+        catch
+            % Corrupted cache, recompute
+            cachedClim = [];
+        end
+    end
 
     numberOfYPlanes=NaN;
     %for parforI=1:1
@@ -283,7 +338,7 @@ else
             % Make sure worker has the right credentials
             awsSetCredentials;
         end
-            
+
         %Get all the JSON files, so we can read c
         % Any fileDatastore request to AWS S3 is limited to 1000 files in 
         % MATLAB 2021a. Due to this bug, we have replaced all calls to 
@@ -291,102 +346,160 @@ else
         % 'https://www.mathworks.com/matlabcentral/answers/502559-filedatastore-request-to-aws-s3-limited-to-1000-files'
         dsJsons = imageDatastore(outputFilePaths{3},'ReadFcn',@awsReadJSON, ...
             'FileExtensions','.json'); 
+        % Exclude bookkeeping files (_clim.json, reconstructConfig.json) from per-frame list
+        allJsonFiles = dsJsons.Files;
+        keep = true(size(allJsonFiles));
+        for k = 1:length(allJsonFiles)
+            [~,bn,~] = fileparts(allJsonFiles{k});
+            if startsWith(bn,'_') || strcmp(bn,'reconstructConfig') || strcmp(bn,'TifMetadata')
+                keep(k) = false;
+            end
+        end
+        dsJsons.Files = allJsonFiles(keep);
+
         cJsons = dsJsons.readall();
         cFrameMins = cellfun(@(x)(min(x.c)),cJsons);
         cFrameMaxs = cellfun(@(x)(max(x.c)),cJsons);
-        
+
         numberOfYPlanes(parforI) = length(cJsons);
-        cOut(parforI,:) = [min(cFrameMins) max(cFrameMaxs)];
+
+        if ~isempty(cachedClim)
+            cOut(parforI,:) = cachedClim(:)';
+        else
+            cOut(parforI,:) = [min(cFrameMins) max(cFrameMaxs)];
+        end
+
         if isempty(c) %Set the internal value
             cStack = cOut(parforI,:); % Use the value from the worker
         else
             cStack = c;
         end
 
-        % Rewrite individual slides with the same c boundray for all
+        % Persist clim cache atomically so a future resume reuses the same value
+        if isempty(cachedClim)
+            climInProgress = awsModifyPathForCompetability( ...
+                [outputFilePaths{3} '/_clim_inProgress.json']);
+            a = struct();
+            a.c = cStack;
+            awsWriteJSON(a, climInProgress);
+            if awsIsAWSPath(climCachePath)
+                awsCopyFileFolder(climInProgress, climCachePath);
+                try, delete(climInProgress); catch, end
+            else
+                if exist(climCachePath,'file'), delete(climCachePath); end
+                movefile(climInProgress, climCachePath, 'f');
+            end
+        end
+
+        % Step 3: Rewrite slides with unified clim; skip slides already committed
         for frameI = 1:numberOfYPlanes(parforI)
-            % Read frame
-            fpIn = yScanPath(outputFilePaths{3},frameI);
             fpOut = yScanPath(outputFilePaths{2},frameI);
-            
-            % Any fileDatastore request to AWS S3 is limited to 1000 files in 
-            % MATLAB 2021a. Due to this bug, we have replaced all calls to 
-            % fileDatastore with imageDatastore since the bug does not affect imageDatastore. 
+
+            if awsExist(fpOut,'file'); continue; end % already committed
+
+            fpIn = yScanPath(outputFilePaths{3},frameI);
+
+            % Any fileDatastore request to AWS S3 is limited to 1000 files in
+            % MATLAB 2021a. Due to this bug, we have replaced all calls to
+            % fileDatastore with imageDatastore since the bug does not affect imageDatastore.
             % 'https://www.mathworks.com/matlabcentral/answers/502559-filedatastore-request-to-aws-s3-limited-to-1000-files'
             ds = imageDatastore(fpIn,'readFcn',@imread);
             bits = ds.read();
-            
+
             % Write a new frame
             tn = [tempname '.tif'];
-            
-            data = yOCT2Tif_ConvertBitsData(bits,...
+
+            dataConverted = yOCT2Tif_ConvertBitsData(bits,...
                 [cFrameMins(frameI) cFrameMaxs(frameI)],true);
-            newBits = yOCT2Tif_ConvertBitsData(data,cStack,false);
+            newBits = yOCT2Tif_ConvertBitsData(dataConverted,cStack,false);
 
             imwrite(newBits,tn);
             awsCopyFile_MW1(tn,fpOut); %Matlab worker version of copy files
             delete(tn);
-        end 
+        end
     end %Run once but on a worker
     if isempty(c)
         c = cOut; % Use the value from the worker
     end
-    
-    % Remove partial tifs
-    awsRmDir(outputFilePaths{3});
 
-    % Finish up copying files
+    % Commit rewritten slides
     awsCopyFile_MW2(outputFilePaths{2});
-    
-    % Finish generating a folder by placing metadata
+
+    % Step 4: Write TifMetadata.json atomically
     metaJson = buildTiffVolumeMetadata(metadata,c);
-    awsWriteJSON(metaJson, ...
-                [outputFilePaths{2} '/TifMetadata.json']);
-    
-    % Generate a single file if required
-    % Instead of loading the entire volume into memory at once, we build
-    % the output TIFF slide by slide: read one frame, write it, discard it.
-    % This keeps memory usage at 1 slide instead of N slides.
+    metadataFinalPath = awsModifyPathForCompetability( ...
+        [outputFilePaths{2} '/TifMetadata.json']);
+    metadataInProgress = awsModifyPathForCompetability( ...
+        [outputFilePaths{2} '/TifMetadata_inProgress.json']);
+    awsWriteJSON(metaJson, metadataInProgress);
+    if awsIsAWSPath(metadataFinalPath)
+        awsCopyFileFolder(metadataInProgress, metadataFinalPath);
+        try, delete(metadataInProgress); catch, end
+    else
+        if exist(metadataFinalPath,'file'), delete(metadataFinalPath); end
+        movefile(metadataInProgress, metadataFinalPath, 'f');
+    end
+
+    % Step 5: Build BigTIFF atomically (_inProgress -> rename); skip if final already exists
     if isOutputFile
         metaJson = buildTiffVolumeMetadata(metadata, c);
 
-        % For local paths, write directly to the output to avoid filling
-        % the system temp drive with a multi GB BigTIFF.
-        % For AWS, write to a temp file first then upload.
-        if isAWS
-            tn = [tempname '.tif'];
-        else
-            tn = outputFilePaths{1};
-        end
-        t = Tiff(tn, 'w8');  % BigTIFF to support files > 4 GB
+        alreadyHaveFinal = in.resume && awsExist(outputFilePaths{1},'file');
 
-        for frameI = 1:numberOfYPlanes
-            % Read one slide from the folder
-            fpSlide = yScanPath(outputFilePaths{2}, frameI);
-            ds = imageDatastore(fpSlide, 'readFcn', @imread);
-            bits = ds.read();
-
-            if frameI > 1
-                t.writeDirectory();
+        if ~alreadyHaveFinal
+            % Write to _inProgress sibling; final name only appears after rename
+            if isAWS
+                tnLocal = [tempname '.tif'];
+                finalDest = outputFilePaths{1};
+            else
+                [finalFolder, finalBase, finalExt] = fileparts(outputFilePaths{1});
+                if isempty(finalFolder)
+                    finalFolder = pwd;
+                end
+                tnLocal = fullfile(finalFolder, [finalBase '_inProgress' finalExt]);
+                finalDest = outputFilePaths{1};
+                % Clear any stale _inProgress from a prior crash
+                if exist(tnLocal,'file')
+                    delete(tnLocal);
+                end
             end
 
-            tagstruct = buildTiffFrameTags(bits, metaJson, metadata, numberOfYPlanes);
-            t.setTag(tagstruct);
-            t.write(uint16(bits));
-        end
-        t.close();
+            t = Tiff(tnLocal, 'w8');  % BigTIFF to support files > 4 GB
 
-        % For AWS, copy the assembled file to the final destination
-        if isAWS
-            awsCopyFileFolder(tn, outputFilePaths{1});
-            delete(tn);
+            for frameI = 1:numberOfYPlanes
+                % Read one slide from the folder
+                fpSlide = yScanPath(outputFilePaths{2}, frameI);
+                ds = imageDatastore(fpSlide, 'readFcn', @imread);
+                bits = ds.read();
+
+                if frameI > 1
+                    t.writeDirectory();
+                end
+
+                tagstruct = buildTiffFrameTags(bits, metaJson, metadata, numberOfYPlanes);
+                t.setTag(tagstruct);
+                t.write(uint16(bits));
+            end
+            t.close();
+
+            % Atomic commit
+            if isAWS
+                awsCopyFileFolder(tnLocal, finalDest);
+                delete(tnLocal);
+            else
+                if exist(finalDest,'file'), delete(finalDest); end
+                movefile(tnLocal, finalDest, 'f');
+            end
         end
     end
-    
+
+    % Step 6: All artifacts committed, safe to remove partialMode
+    awsRmDir(outputFilePaths{3});
+
     % If output folder is not required, delete it
     if ~isOutputFolder
         awsRmDir(outputFilePaths{2});
-    end 
+    end
 end
 
 function p = yScanPath(outputFilePaths,yIndex)

--- a/Processing/test_yOCTProcessTiledScan.m
+++ b/Processing/test_yOCTProcessTiledScan.m
@@ -648,6 +648,84 @@ classdef test_yOCTProcessTiledScan < matlab.unittest.TestCase
             testCase.verifyEqual(climOut(:)', climRef(:)', 'AbsTol', 1e-6, ...
                 'Corrupted clim must be recomputed, matching a clean run');
         end
+
+        function testResume_OrphanStageDirInOutputFolder_IsCleaned(testCase)
+            % If MATLAB is interrupted mid-write, a y####.tif/ directory can remain in
+            % the output folder instead of a file. imageDatastore crashes on it.
+            % Step 1b sweeps those orphans before the BigTIFF build.
+            % Test that resume completes successfully and output matches a clean run.
+
+            [scanFolder, outFile] = testCase.makeResumeFixture('orphan_out');
+            commonArgs = { ...
+                'focusPositionInImageZpix', 1, ...
+                'focusSigma', 1000, ...
+                'dispersionQuadraticTerm', 0, ...
+                'v', false};
+
+            % Reference: clean run
+            [~, refOut] = testCase.makeResumeFixture('orphan_out_ref');
+            yOCTProcessTiledScan(scanFolder, {refOut}, commonArgs{:}, 'resume', false);
+            [dataRef, ~] = yOCTFromTif(refOut);
+
+            % First clean run to get a complete partialMode/ with per-frame
+            % .tif.json sidecars (so mode 2 is a no-op on the next resume).
+            yOCTProcessTiledScan(scanFolder, {outFile}, commonArgs{:}, 'resume', false);
+
+            % Simulate a crash mid-Step 3: delete the final BigTIFF and plant
+            % an orphan y0001.tif/ directory in the output folder where the
+            % slide file would be.
+            delete(outFile);
+            companion = [outFile '.fldr'];
+            slidePath = fullfile(companion, 'y0001.tif');
+            if exist(slidePath,'file'); delete(slidePath); end
+            mkdir(slidePath); % orphan directory where a file is expected
+
+            % Resume must sweep the orphan, rebuild the slide + BigTIFF,
+            % and produce output identical to the reference.
+            yOCTProcessTiledScan(scanFolder, {outFile}, commonArgs{:}, 'resume', true);
+            testCase.verifyTrue(exist(outFile,'file') == 2, ...
+                'Final BigTIFF must exist after resume');
+            testCase.verifyFalse(exist(slidePath,'dir') == 7, ...
+                'Orphan y####.tif/ directory must be removed');
+            [dataResume, ~] = yOCTFromTif(outFile);
+            testCase.verifyLessThan( ...
+                max(abs(double(dataResume(:)) - double(dataRef(:)))), 1e-6, ...
+                'Output must match the clean reference after orphan sweep');
+        end
+
+        function testResume_OrphanStageDirInPartialMode_IsCleaned(testCase)
+            % Same bug as above but the orphan y####.tif/ lives in partialMode/.
+            % Mode 1 resume sweeps it so mode 2 can re-stage that frame.
+            % Test that resume completes successfully and output matches a clean run.
+
+            [scanFolder, outFile] = testCase.makeResumeFixture('orphan_partial');
+            commonArgs = { ...
+                'focusPositionInImageZpix', 1, ...
+                'focusSigma', 1000, ...
+                'dispersionQuadraticTerm', 0, ...
+                'v', false};
+
+            % Reference: clean run
+            [~, refOut] = testCase.makeResumeFixture('orphan_partial_ref');
+            yOCTProcessTiledScan(scanFolder, {refOut}, commonArgs{:}, 'resume', false);
+            [dataRef, ~] = yOCTFromTif(refOut);
+
+            % Plant an orphan y0001.tif/ directory in partialMode/ BEFORE
+            % any run (so mode 2 will have to redo that frame).
+            companion = [outFile '.fldr'];
+            partialFolder = fullfile(companion, 'partialMode');
+            mkdir(partialFolder);
+            orphanPath = fullfile(partialFolder, 'y0001.tif');
+            mkdir(orphanPath);
+
+            yOCTProcessTiledScan(scanFolder, {outFile}, commonArgs{:}, 'resume', true);
+            testCase.verifyTrue(exist(outFile,'file') == 2, ...
+                'Final BigTIFF must exist after resume');
+            [dataResume, ~] = yOCTFromTif(outFile);
+            testCase.verifyLessThan( ...
+                max(abs(double(dataResume(:)) - double(dataRef(:)))), 1e-6, ...
+                'Output must match the clean reference after orphan sweep in partialMode');
+        end
     end
 
     methods (Access = private)

--- a/Processing/test_yOCTProcessTiledScan.m
+++ b/Processing/test_yOCTProcessTiledScan.m
@@ -12,6 +12,41 @@ classdef test_yOCTProcessTiledScan < matlab.unittest.TestCase
     end
     
     methods (Access = private)
+        function [scanFolder, outFile] = makeResumeFixture(testCase, suffix)
+            % Helper: build a fresh simulated scan + output paths inside a
+            % unique tmp directory and register cleanup so leftovers never
+            % pollute the workspace if a test fails mid-way.
+            stamp = datestr(now, 'yyyymmdd_HHMMSSFFF');
+            scanFolder = ['tmp_resume_' suffix '_' stamp '/'];
+            outFile    = ['tmp_resume_' suffix '_' stamp '.tif'];
+
+            dummyData = zeros(400,200,2)+1;
+            dummyData([50,150],:,:) = 100;
+            octProbePath = yOCTGetProbeIniPath('40x', 'OCTP900', 'SUMMER');
+
+            yOCTSimulateTileScan(dummyData, scanFolder, ...
+                'pixelSize_um', 1, ...
+                'zDepths', 0, ...
+                'focusPositionInImageZpix', 1, ...
+                'focusSigma', 1000, ...
+                'octProbePath', octProbePath);
+
+            companion = [outFile '.fldr'];
+            testCase.addTeardown(@() testCase.cleanupResumeFixture( ...
+                scanFolder, outFile, companion));
+        end
+
+        function cleanupResumeFixture(~, scanFolder, outFile, companion)
+            if exist(scanFolder,'dir');  rmdir(scanFolder,'s');  end
+            if exist(outFile,'file');    delete(outFile);        end
+            if exist(companion,'dir');   rmdir(companion,'s');   end
+            % Also delete any stray inProgress sibling
+            [folder, base, ext] = fileparts(outFile);
+            if isempty(folder); folder = pwd; end
+            stale = fullfile(folder, [base '_inProgress' ext]);
+            if exist(stale,'file'); delete(stale); end
+        end
+
         function setupCropSimulation(testCase)
             % Shared simulation setup for cropZRange tests.
             % This creates simulated scan data that all crop tests reuse.
@@ -335,6 +370,332 @@ classdef test_yOCTProcessTiledScan < matlab.unittest.TestCase
                 'Partial overlap should have fewer Z pixels than full range');
             testCase.verifyGreaterThan(length(dimHalf.z.values), length(dimFull.z.values) * 0.3, ...
                 'Partial overlap should have at least 30% of Z pixels (approximately half)');
+        end
+
+        function testResume_AfterInterruptedFinalize(testCase)
+            % Resume after a crash that happened during the finalization
+            % stage of a previous run. We simulate this by:
+            %   1. Running a clean reference run.
+            %   2. Running a second clean run, then deleting the final BigTIFF,
+            %      half of the rewritten per-y slides, and TifMetadata.json.
+            %      This is the on-disk state a crash mid-finalize would leave
+            %      (parfor frames are still committed in partialMode/).
+            %   3. Calling again with resume=true and verifying the recovered
+            %      output is bit-for-bit identical to the reference.
+            % NOTE: we cannot actually crash mid-parfor from a unit test, so
+            % this test focuses on the steps that come AFTER parfor.
+
+            [scanFolder, refOut] = testCase.makeResumeFixture('ref');
+            [~,         resumeOut] = testCase.makeResumeFixture('out');
+
+            commonArgs = { ...
+                'focusPositionInImageZpix', 1, ...
+                'focusSigma', 1000, ...
+                'dispersionQuadraticTerm', 0, ...
+                'v', false};
+
+            % Reference (single-shot)
+            yOCTProcessTiledScan(scanFolder, {refOut}, commonArgs{:}, 'resume', false);
+            testCase.assertTrue(exist(refOut,'file') == 2, ...
+                'Reference run must produce a final BigTIFF');
+            [dataRef, ~] = yOCTFromTif(refOut);
+
+            % Run #1 of the resume scenario (clean run that we will mutilate)
+            yOCTProcessTiledScan(scanFolder, {resumeOut}, commonArgs{:}, 'resume', false);
+
+            % Mutilate to mimic a crash that happened during finalize:
+            %   - delete the final BigTIFF
+            %   - delete TifMetadata.json
+            %   - delete half of the rewritten per-y slides
+            % Note we keep partialMode/ contents intact (parfor was finished).
+            delete(resumeOut);
+            companion = [resumeOut '.fldr'];
+            metaFile = fullfile(companion, 'TifMetadata.json');
+            if exist(metaFile,'file'); delete(metaFile); end
+            slideFiles = dir(fullfile(companion, 'y*.tif'));
+            for k = 1:floor(length(slideFiles)/2)
+                delete(fullfile(companion, slideFiles(k).name));
+            end
+
+            % Resume must rebuild the deleted artifacts and produce a final
+            % file numerically identical to the reference.
+            yOCTProcessTiledScan(scanFolder, {resumeOut}, commonArgs{:}, 'resume', true);
+            testCase.verifyTrue(exist(resumeOut,'file') == 2, ...
+                'Resume must produce final BigTIFF');
+            [dataResume, ~] = yOCTFromTif(resumeOut);
+
+            testCase.verifyEqual(size(dataResume), size(dataRef), ...
+                'Resumed output volume shape must match reference');
+            testCase.verifyLessThan( ...
+                max(abs(double(dataResume(:)) - double(dataRef(:)))), 1e-6, ...
+                'Resumed output must be numerically identical to reference');
+        end
+
+        function testResume_StaleInProgressBigTIFF_IsCleared(testCase)
+            % If a previous run crashed mid-write, an _inProgress.tif may
+            % remain alongside the (missing) final file. The next resume
+            % must delete it and produce a complete final BigTIFF.
+
+            [scanFolder, outFile] = testCase.makeResumeFixture('stale');
+            commonArgs = { ...
+                'focusPositionInImageZpix', 1, ...
+                'focusSigma', 1000, ...
+                'dispersionQuadraticTerm', 0, ...
+                'v', false};
+
+            % Build a complete output first
+            yOCTProcessTiledScan(scanFolder, {outFile}, commonArgs{:}, 'resume', false);
+
+            % Simulate crash mid-BigTIFF: delete final file, keep slides in
+            % the companion folder, plant a stale _inProgress sibling.
+            delete(outFile);
+            [folder, base, ext] = fileparts(outFile);
+            if isempty(folder); folder = pwd; end
+            stale = fullfile(folder, [base '_inProgress' ext]);
+            fid = fopen(stale,'w'); fwrite(fid,'corrupt'); fclose(fid);
+            testCase.assertTrue(exist(stale,'file') == 2);
+
+            % Resume must clear the stale file and produce a valid final.
+            yOCTProcessTiledScan(scanFolder, {outFile}, commonArgs{:}, 'resume', true);
+            testCase.verifyTrue(exist(outFile,'file') == 2, ...
+                'Final BigTIFF must exist after resume');
+            testCase.verifyFalse(exist(stale,'file') == 2, ...
+                'Stale _inProgress sibling must be removed after resume');
+        end
+
+        function testResume_ClimIsReused(testCase)
+            % The clim used to rewrite slides + assemble the BigTIFF is
+            % saved as _clim.json in partialMode/. A resume must reuse it
+            % so that the final output is deterministic across runs.
+            %
+            % Strategy: plant a sentinel _clim.json BEFORE the first run so
+            % that partialMode/ already has it when mode 3 runs.
+            % The parfor (mode 2) still executes fresh (no committed .tif.json),
+            % but mode 3 Honours the pre-existing _clim.json instead of
+            % recomputing from per-frame data.
+            %
+            % Note: after mode 3, the companion *.tif.fldr/ folder is
+            % deleted. The sentinel clim is verified by reading
+            % it back from the TIFF's embedded Software tag via yOCTFromTif.
+
+            [scanFolder, outFile] = testCase.makeResumeFixture('clim');
+            commonArgs = { ...
+                'focusPositionInImageZpix', 1, ...
+                'focusSigma', 1000, ...
+                'dispersionQuadraticTerm', 0, ...
+                'v', false};
+
+            % Pre-plant a sentinel _clim.json so mode 3 uses it.
+            % (partialMode/ does not exist yet; create it before the run.)
+            companion = [outFile '.fldr'];
+            partialFolder = fullfile(companion, 'partialMode');
+            mkdir(partialFolder);
+            sentinelClim = [-12345.5, 12345.5];
+            climPayload = struct(); climPayload.c = sentinelClim;
+            awsWriteJSON(climPayload, fullfile(partialFolder, '_clim.json'));
+
+            % Run with resume=true: parfor runs fresh (no committed .tif.json),
+            % then mode 3 picks up the sentinel clim and embeds it in the BigTIFF.
+            yOCTProcessTiledScan(scanFolder, {outFile}, commonArgs{:}, 'resume', true);
+            testCase.assertTrue(exist(outFile,'file') == 2, ...
+                'Final BigTIFF must exist after resume run');
+
+            % The clim is embedded in the BigTIFF's Software TIFF tag as JSON;
+            % yOCTFromTif's third output returns it directly.
+            [~, ~, climOut] = yOCTFromTif(outFile);
+            testCase.verifyEqual(climOut(:)', sentinelClim, 'AbsTol', 1e-9, ...
+                'Resume must honour the cached _clim.json instead of recomputing');
+        end
+
+        function testResume_ConfigMismatch_FocusSigma(testCase)
+            % Changing focusSigma between runs must abort with a precise error.
+            testCase.verifyConfigMismatchError('focusSigma', 1000, 500);
+        end
+
+        function testResume_ConfigMismatch_DispersionQuadraticTerm(testCase)
+            testCase.verifyConfigMismatchError('dispersionQuadraticTerm', 0, 79430000);
+        end
+
+        function testResume_ConfigMismatch_FocusPosition(testCase)
+            testCase.verifyConfigMismatchError('focusPositionInImageZpix', 1, 100);
+        end
+
+        function testResume_SkipsWhenFullyDone(testCase)
+            % Calling yOCTProcessTiledScan on an already-complete output is
+            % a no-op: it must emit the dedicated warning and leave the
+            % file untouched (same size, same mtime).
+
+            [scanFolder, outFile] = testCase.makeResumeFixture('done');
+            commonArgs = { ...
+                'focusPositionInImageZpix', 1, ...
+                'focusSigma', 1000, ...
+                'dispersionQuadraticTerm', 0, ...
+                'v', false};
+
+            yOCTProcessTiledScan(scanFolder, {outFile}, commonArgs{:});
+            testCase.assertTrue(exist(outFile,'file') == 2, ...
+                'First run must produce final file');
+            info1 = dir(outFile);
+
+            companion = [outFile '.fldr'];
+            partialPath = fullfile(companion, 'partialMode');
+            testCase.verifyFalse(exist(partialPath,'dir') == 7, ...
+                'partialMode/ must be removed after a clean run');
+
+            pause(1.1); % allow mtime resolution to detect any change
+            testCase.verifyWarning( ...
+                @() yOCTProcessTiledScan(scanFolder, {outFile}, ...
+                    commonArgs{:}, 'resume', true), ...
+                'yOCTProcessTiledScan:outputAlreadyDone');
+
+            info2 = dir(outFile);
+            testCase.verifyEqual(info2.bytes, info1.bytes, ...
+                'File size must not change on a no-op resume');
+            testCase.verifyEqual(info2.datenum, info1.datenum, ...
+                'File mtime must not change on a no-op resume');
+        end
+
+        function testResume_HalfCommittedFrame_IsRedone(testCase)
+            % Crash between writing y####.tif and writing y####.tif.json:
+            % only the .tif is on disk. The resume must NOT treat that as
+            % "done" (the .json is the completion marker); it must redo
+            % that frame so the final output matches a clean run.
+
+            [scanFolder, outFile] = testCase.makeResumeFixture('half');
+            commonArgs = { ...
+                'focusPositionInImageZpix', 1, ...
+                'focusSigma', 1000, ...
+                'dispersionQuadraticTerm', 0, ...
+                'v', false};
+
+            % Reference: clean single-shot run
+            [~, refOut] = testCase.makeResumeFixture('half_ref');
+            yOCTProcessTiledScan(scanFolder, {refOut}, commonArgs{:}, 'resume', false);
+            [dataRef, ~] = yOCTFromTif(refOut);
+
+            % Plant a lone y0001.tif in partialMode/ without its .json sibling,
+            % then run with resume=true and verify output matches the reference.
+            companion = [outFile '.fldr'];
+            partialFolder = fullfile(companion, 'partialMode');
+            mkdir(partialFolder);
+            fid = fopen(fullfile(partialFolder,'y0001.tif'),'w');
+            fwrite(fid, uint8(zeros(100,1))); fclose(fid);
+
+            yOCTProcessTiledScan(scanFolder, {outFile}, commonArgs{:}, 'resume', true);
+            [dataResume, ~] = yOCTFromTif(outFile);
+            testCase.verifyLessThan( ...
+                max(abs(double(dataResume(:)) - double(dataRef(:)))), 1e-6, ...
+                'Half-committed frame must be redone, not skipped');
+        end
+
+        function testResume_StaleInProgressSidecars_AreOverwritten(testCase)
+            % Any crash can leave stale _inProgress sidecars on disk
+            % (_clim_inProgress.json, TifMetadata_inProgress.json,
+            % reconstructConfig_inProgress.json). A resume must ignore
+            % their stale content and still produce a valid final file.
+
+            [scanFolder, outFile] = testCase.makeResumeFixture('sidecars');
+            commonArgs = { ...
+                'focusPositionInImageZpix', 1, ...
+                'focusSigma', 1000, ...
+                'dispersionQuadraticTerm', 0, ...
+                'v', false};
+
+            companion = [outFile '.fldr'];
+            partialFolder = fullfile(companion, 'partialMode');
+            mkdir(partialFolder);
+
+            % Plant the three stale _inProgress sidecars with garbage.
+            staleFiles = { ...
+                fullfile(partialFolder, '_clim_inProgress.json'), ...
+                fullfile(partialFolder, 'reconstructConfig_inProgress.json'), ...
+                fullfile(companion,    'TifMetadata_inProgress.json')};
+            for k = 1:length(staleFiles)
+                fid = fopen(staleFiles{k},'w'); fwrite(fid,'corrupt'); fclose(fid);
+            end
+
+            yOCTProcessTiledScan(scanFolder, {outFile}, commonArgs{:}, 'resume', true);
+            testCase.verifyTrue(exist(outFile,'file') == 2, ...
+                'Resume must still produce the final file despite stale sidecars');
+        end
+
+        function testResume_CorruptedClimCache_IsRecomputed(testCase)
+            % A corrupted _clim.json (invalid JSON from an interrupted write)
+            % must not abort the run. Mode 3 wraps the read in try/catch and
+            % falls back to recomputing clim from the per-frame sidecars.
+
+            [scanFolder, outFile] = testCase.makeResumeFixture('bad_clim');
+            commonArgs = { ...
+                'focusPositionInImageZpix', 1, ...
+                'focusSigma', 1000, ...
+                'dispersionQuadraticTerm', 0, ...
+                'v', false};
+
+            % Reference clim from a clean run.
+            [~, refOut] = testCase.makeResumeFixture('bad_clim_ref');
+            yOCTProcessTiledScan(scanFolder, {refOut}, commonArgs{:}, 'resume', false);
+            [~, ~, climRef] = yOCTFromTif(refOut);
+
+            % Plant an invalid _clim.json, then run.
+            companion = [outFile '.fldr'];
+            partialFolder = fullfile(companion, 'partialMode');
+            mkdir(partialFolder);
+            fid = fopen(fullfile(partialFolder,'_clim.json'),'w');
+            fwrite(fid, 'this is not valid json {{{'); fclose(fid);
+
+            yOCTProcessTiledScan(scanFolder, {outFile}, commonArgs{:}, 'resume', true);
+            [~, ~, climOut] = yOCTFromTif(outFile);
+            testCase.verifyEqual(climOut(:)', climRef(:)', 'AbsTol', 1e-6, ...
+                'Corrupted clim must be recomputed, matching a clean run');
+        end
+    end
+
+    methods (Access = private)
+        function verifyConfigMismatchError(testCase, fieldName, prevValue, newValue)
+            % Shared helper: write a config guard with prevValue and verify
+            % that resuming with newValue throws resumeConfigMismatch.
+            [scanFolder, outFile] = testCase.makeResumeFixture(['guard_' fieldName]);
+            companion = [outFile '.fldr'];
+            partialFolder = fullfile(companion, 'partialMode');
+            mkdir(partialFolder);
+
+            % Build a minimal but complete previous-config guard.
+            guard = struct();
+            guard.tiledScanInputFolder      = 'irrelevant';
+            guard.dispersionQuadraticTerm   = 0;
+            guard.focusSigma                = 1000;
+            guard.focusPositionInImageZpix  = 1;
+            guard.cropZRange_mm             = [];
+            guard.outputFilePixelSize_um    = 1;
+            guard.applyPathLengthCorrection = true;
+            guard.reconstructConfig         = {};
+            guard.(fieldName) = prevValue;
+            awsWriteJSON(guard, fullfile(partialFolder,'reconstructConfig.json'));
+
+            % Drop a dummy committed yI so partialMode is non-trivial.
+            fid = fopen(fullfile(partialFolder,'y0001.tif'),'w'); fclose(fid);
+            fid = fopen(fullfile(partialFolder,'y0001.tif.json'),'w');
+            fprintf(fid,'{"c":[0,1]}'); fclose(fid);
+
+            % Build the resume call args, replacing the field under test.
+            args = { ...
+                'focusPositionInImageZpix', 1, ...
+                'focusSigma', 1000, ...
+                'dispersionQuadraticTerm', 0, ...
+                'v', false, ...
+                'resume', true};
+            for k = 1:2:length(args)
+                if strcmp(args{k}, fieldName)
+                    args{k+1} = newValue;
+                end
+            end
+
+            % Use the fixture's scanFolder so ScanInfo.json is available;
+            % the call should fail at the config-guard check long before
+            % touching the actual scan data.
+            testCase.verifyError( ...
+                @() yOCTProcessTiledScan(scanFolder, {outFile}, args{:}), ...
+                'yOCTProcessTiledScan:resumeConfigMismatch');
         end
     end
 end

--- a/Processing/yOCTProcessTiledScan.m
+++ b/Processing/yOCTProcessTiledScan.m
@@ -68,6 +68,10 @@ addParameter(p,'applyPathLengthCorrection',true); %TODO(yonatan) shift this para
 % Output file resolution
 addParameter(p,'outputFilePixelSize_um',1,@(x)(isempty(x) || (isnumeric(x) && isscalar(x) && x>0)));
 
+% Safe stop/resume: if true, pick up where a previous run left off (skip frames
+% and slides already committed, reuse saved clim). Set false to force a fresh run.
+addParameter(p,'resume',true,@islogical);
+
 p.KeepUnmatched = true;
 if (~iscell(varargin{1}))
     parse(p,varargin{:});
@@ -234,8 +238,8 @@ if ~isempty(in.yPlanesOutputFolder) && in.howManyYPlanes > 0
     isSaveSomeYPlanes = true;
     yPlanesOutputFolder = awsModifyPathForCompetability([in.yPlanesOutputFolder '/']);
     
-    % Clear folder if it exists
-    if awsExist(yPlanesOutputFolder)
+    % On resume, keep existing debug snapshots; new ones will overwrite by name
+    if ~in.resume && awsExist(yPlanesOutputFolder)
         awsRmDir(yPlanesOutputFolder);
     end
     
@@ -253,12 +257,139 @@ imOutSize = [...
     length(dimOutput_mm.x.values) ...
     length(dimOutput_mm.y.values)];
 printStatsEveryyI = max(floor(length(dimOutput_mm.y.values)/20),1);
+
+% If the output already exists and no partial work remains, nothing to do.
+% Must be checked BEFORE yOCT2Tif mode 1 (which always creates partialMode/).
+if in.resume
+    % Locate where partialMode/ would be, matching yOCT2Tif's convention
+    allFinalFilesExist = true;
+    outputFolderForPartial = '';
+    for kOut = 1:length(outputPath)
+        op = outputPath{kOut};
+        [~,~,ext] = fileparts(op);
+        if ~isempty(ext)
+            % File output
+            if ~awsExist(op,'file')
+                allFinalFilesExist = false;
+            end
+            if isempty(outputFolderForPartial)
+                outputFolderForPartial = awsModifyPathForCompetability([op '.fldr/']);
+            end
+        else
+            % Folder output
+            folderPath = awsModifyPathForCompetability([op '/']);
+            metaPath = awsModifyPathForCompetability([folderPath 'TifMetadata.json']);
+            if ~awsExist(metaPath,'file')
+                allFinalFilesExist = false;
+            end
+            outputFolderForPartial = folderPath; % prefer folder over .fldr sibling
+        end
+    end
+    partialModePath = awsModifyPathForCompetability( ...
+        [outputFolderForPartial 'partialMode/']);
+    partialStillExists = awsExist(partialModePath,'dir');
+
+    if allFinalFilesExist && ~partialStillExists
+        warning('yOCTProcessTiledScan:outputAlreadyDone', ...
+            ['Output already exists and no partial work remains. Nothing to do.\n' ...
+            'To regenerate: delete the output files and re-run, ' ...
+            'or pass ''resume'', false to force a fresh run.']);
+        return;
+    end
+end
+
 ticBytes(gcp);
 if(v)
     fprintf('%s Stitching ...\n',datestr(datetime)); tt=tic();
 end
-whereAreMyFiles = yOCT2Tif([], outputPath, 'partialFileMode', 1); %Init
+whereAreMyFiles = yOCT2Tif([], outputPath, 'partialFileMode', 1, 'resume', in.resume); %Init
+
+% Guard against resuming with different inputs: save the current config and
+% compare against a previous run. Mismatch -> clear error, not silent corruption.
+configGuardPath = awsModifyPathForCompetability( ...
+    [whereAreMyFiles '/reconstructConfig.json']);
+newConfig = struct();
+newConfig.tiledScanInputFolder     = tiledScanInputFolder;
+newConfig.dispersionQuadraticTerm  = in.dispersionQuadraticTerm;
+newConfig.focusSigma               = in.focusSigma;
+newConfig.focusPositionInImageZpix = in.focusPositionInImageZpix;
+newConfig.cropZRange_mm            = in.cropZRange_mm;
+newConfig.outputFilePixelSize_um   = in.outputFilePixelSize_um;
+newConfig.applyPathLengthCorrection= in.applyPathLengthCorrection;
+newConfig.reconstructConfig        = reconstructConfig;
+
+if in.resume && awsExist(configGuardPath,'file')
+    try
+        prevConfig = awsReadJSON(configGuardPath);
+    catch
+        prevConfig = [];
+    end
+    if ~isempty(prevConfig)
+        mismatchLines = {};
+        fn = fieldnames(newConfig);
+        for k = 1:length(fn)
+            f = fn{k};
+            if ~isfield(prevConfig,f) || ~isequaln(prevConfig.(f), newConfig.(f))
+                prevStr = '<missing>';
+                if isfield(prevConfig,f)
+                    prevStr = yOCTProcessTiledScan_formatConfigValue(prevConfig.(f));
+                end
+                curStr = yOCTProcessTiledScan_formatConfigValue(newConfig.(f));
+                mismatchLines{end+1} = sprintf('    %s: previous=%s, current=%s', f, prevStr, curStr); %#ok<AGROW>
+            end
+        end
+        if ~isempty(mismatchLines)
+            msg = sprintf(['Cannot resume: the following inputs differ from the previous run:\n%s\n\n'...
+                'Partial data lives at:\n    %s\n\n'...
+                'Options to resolve:\n'...
+                '    1) Re-run with the previous input values.\n'...
+                '    2) Delete the partial folder above and re-run to start fresh.\n'...
+                '    3) Re-run passing ''resume'', false to force a fresh run.'], ...
+                strjoin(mismatchLines, newline), whereAreMyFiles);
+            error('yOCTProcessTiledScan:resumeConfigMismatch', '%s', msg);
+        end
+    end
+end
+% Always (re)write the guard to keep it in sync with the current inputs
+configInProgress = awsModifyPathForCompetability( ...
+    [whereAreMyFiles '/reconstructConfig_inProgress.json']);
+awsWriteJSON(newConfig, configInProgress);
+if awsIsAWSPath(configGuardPath)
+    awsCopyFileFolder(configInProgress, configGuardPath);
+    try, delete(configInProgress); catch, end
+else
+    if exist(configGuardPath,'file'), delete(configGuardPath); end
+    movefile(configInProgress, configGuardPath, 'f');
+end
+
+% Find frames already done (y####.tif.json present = frame complete)
+alreadyDoneYI = false(1,length(dimOutput_mm.y.values));
+if in.resume
+    for yI = 1:length(dimOutput_mm.y.values)
+        finalJsonPath = awsModifyPathForCompetability( ...
+            sprintf('%s/y%04d.tif.json', whereAreMyFiles, yI));
+        if awsExist(finalJsonPath,'file')
+            alreadyDoneYI(yI) = true;
+        end
+    end
+end
+numAlreadyDone = sum(alreadyDoneYI);
+if v && numAlreadyDone > 0
+    fprintf('%s Resume: %d / %d yI frames already committed, will be skipped.\n', ...
+        datestr(datetime), numAlreadyDone, length(dimOutput_mm.y.values));
+end
+
 parfor yI=1:length(dimOutput_mm.y.values) 
+    % Skip frames already done; re-check inside parfor in case of race
+    if alreadyDoneYI(yI)
+        continue;
+    end
+    finalJsonPath = awsModifyPathForCompetability( ...
+        sprintf('%s/y%04d.tif.json', whereAreMyFiles, yI));
+    if awsExist(finalJsonPath,'file')
+        continue;
+    end
+
     try
         % Create a container for all data
         stack = zeros(imOutSize(1:2)); %z,x,zStach
@@ -363,7 +494,7 @@ parfor yI=1:length(dimOutput_mm.y.values)
         
         % Save
         yOCT2Tif(mag2db(stackmean), outputPath, ...
-            'partialFileMode', 2, 'partialFileModeIndex', yI); 
+            'partialFileMode', 2, 'partialFileModeIndex', yI, 'resume', in.resume); 
         
         % Is it time to print statistics?
         if mod(yI,printStatsEveryyI)==0 && v
@@ -430,7 +561,17 @@ if (v)
 end
 
 % Get the main data out
-yOCT2Tif([], outputPath, 'metadata', dimOutput_mm, 'partialFileMode', 3);
+yOCT2Tif([], outputPath, 'metadata', dimOutput_mm, 'partialFileMode', 3, 'resume', in.resume);
+
+% Resume summary (same format as yOCTUnzipTiledScan)
+if v
+    nTotalYI = length(dimOutput_mm.y.values);
+    nNewYI   = nTotalYI - numAlreadyDone;
+    fprintf('\n%s Reconstruction Summary\n', datestr(datetime));
+    fprintf('%s   Total y planes:         %d\n', datestr(datetime), nTotalYI);
+    fprintf('%s   Already reconstructed:  %d\n', datestr(datetime), numAlreadyDone);
+    fprintf('%s   Newly reconstructed:    %d\n', datestr(datetime), nNewYI);
+end
 
 % Get saved y planes out
 if isSaveSomeYPlanes
@@ -453,4 +594,31 @@ function cnt = yOCTProcessTiledScan_AuxCountHowManyYFiles(whereAreMyFiles)
 ds = imageDatastore(whereAreMyFiles,'ReadFcn',@(x)(x),'FileExtensions','.getmeout','IncludeSubfolders',true); %Count all artifacts
 isFile = cellfun(@(x)(contains(lower(x),'.json')),ds.Files);
 cnt = sum(isFile);
+
+
+function s = yOCTProcessTiledScan_formatConfigValue(v)
+% Format a config value as a short string for error messages
+if isnumeric(v) || islogical(v)
+    if isempty(v)
+        s = '[]';
+    elseif isscalar(v)
+        s = mat2str(v);
+    else
+        s = ['[' strjoin(arrayfun(@mat2str, v(:)', 'UniformOutput', false), ' ') ']'];
+    end
+elseif ischar(v)
+    s = ['"' v '"'];
+elseif iscell(v)
+    parts = cell(1, numel(v));
+    for iii = 1:numel(v)
+        parts{iii} = yOCTProcessTiledScan_formatConfigValue(v{iii});
+    end
+    s = ['{' strjoin(parts, ', ') '}'];
+else
+    try
+        s = jsonencode(v);
+    catch
+        s = '<unprintable>';
+    end
+end
 

--- a/Processing/yOCTProcessTiledScan.m
+++ b/Processing/yOCTProcessTiledScan.m
@@ -528,25 +528,28 @@ if (v)
     fprintf('%s Verifying all files are there ... ',datestr(datetime));
 end
 
-% Count how many files are in the library
-cnt = yOCTProcessTiledScan_AuxCountHowManyYFiles(whereAreMyFiles);
-    
+% Count how many files are in the library. On resume, the helper only sees
+% staged (.getmeout) artifacts from this run; frames committed by previous
+% runs live as y####.tif.json directly in whereAreMyFiles, so add them back.
+cnt = yOCTProcessTiledScan_AuxCountHowManyYFiles(whereAreMyFiles) + numAlreadyDone;
+
 if cnt ~= length(dimOutput_mm.y.values)
     % Some files are missing, print debug to help trubleshoot 
     fprintf('\nDebug Data:\n');
     fprintf('whereAreMyFiles = ''%s''\n',whereAreMyFiles);
     fprintf('Number of ds files: %d\n',cnt)
     
-    % Use AWS ls
+    % Use AWS ls. Match only per-frame jsons (y####.tif.json); exclude
+    % bookkeeping files like _clim.json and reconstructConfig.json.
     l = awsls(whereAreMyFiles);
-    isFileL = cellfun(@(x)(contains(lower(x),'.json')),l);
+    isFileL = cellfun(@(x)(~isempty(regexp(lower(x),'y\d+\.tif\.json$','once'))),l);
     cntL = sum(isFileL);
     fprintf('Number of awsls files: %d\n',cntL)
     
-    if (cntL ~= length(yAll))
+    if (cntL ~= length(dimOutput_mm.y.values))
         % Throw an error
         error('Please review "%s". We expect to have %d y planes but see only %d in the folder.\nI didn''t delete folder to allow you to debug.\nPlease remove by running awsRmDir(''%s''); when done.',...
-            whereAreMyFiles,length(yAll),cnt,whereAreMyFiles);
+            whereAreMyFiles,length(dimOutput_mm.y.values),cnt,whereAreMyFiles);
     else
         % This is probably a datastore issue
         warning('fileDatastore returned different number of files when compared to awsls. You might want to trubleshoot why this happend.\nFor background, see: %s',...
@@ -596,9 +599,14 @@ function cnt = yOCTProcessTiledScan_AuxCountHowManyYFiles(whereAreMyFiles)
 % MATLAB 2021a. Due to this bug, we have replaced all calls to 
 % fileDatastore with imageDatastore since the bug does not affect imageDatastore. 
 % 'https://www.mathworks.com/matlabcentral/answers/502559-filedatastore-request-to-aws-s3-limited-to-1000-files'
-ds = imageDatastore(whereAreMyFiles,'ReadFcn',@(x)(x),'FileExtensions','.getmeout','IncludeSubfolders',true); %Count all artifacts
-isFile = cellfun(@(x)(contains(lower(x),'.json')),ds.Files);
-cnt = sum(isFile);
+try
+    ds = imageDatastore(whereAreMyFiles,'ReadFcn',@(x)(x),'FileExtensions','.getmeout','IncludeSubfolders',true); %Count all artifacts
+    isFile = cellfun(@(x)(contains(lower(x),'.json')),ds.Files);
+    cnt = sum(isFile);
+catch
+    % No .getmeout staged files (e.g. full resume with no new work). Not an error.
+    cnt = 0;
+end
 
 
 function s = yOCTProcessTiledScan_formatConfigValue(v)

--- a/Processing/yOCTProcessTiledScan.m
+++ b/Processing/yOCTProcessTiledScan.m
@@ -329,7 +329,12 @@ if in.resume && awsExist(configGuardPath,'file')
         fn = fieldnames(newConfig);
         for k = 1:length(fn)
             f = fn{k};
-            if ~isfield(prevConfig,f) || ~isequaln(prevConfig.(f), newConfig.(f))
+            % Compare via JSON encoding: avoids false positives from floating-point
+            % round-trips through JSON and cell/struct type differences.
+            prevJson = ''; curJson = '';
+            try, prevJson = jsonencode(prevConfig.(f)); catch, end
+            try, curJson  = jsonencode(newConfig.(f));  catch, end
+            if ~isfield(prevConfig,f) || ~strcmp(prevJson, curJson)
                 prevStr = '<missing>';
                 if isfield(prevConfig,f)
                     prevStr = yOCTProcessTiledScan_formatConfigValue(prevConfig.(f));

--- a/Processing/yOCTProcessTiledScan.m
+++ b/Processing/yOCTProcessTiledScan.m
@@ -326,9 +326,13 @@ if in.resume && awsExist(configGuardPath,'file')
     end
     if ~isempty(prevConfig)
         mismatchLines = {};
+        % Paths (tiledScanInputFolder) are excluded from comparison: moving data
+        % to a different drive or PC changes the path but not the reconstruction.
+        fieldsToSkip = {'tiledScanInputFolder'};
         fn = fieldnames(newConfig);
         for k = 1:length(fn)
             f = fn{k};
+            if any(strcmp(f, fieldsToSkip)), continue; end
             % Compare via JSON encoding: avoids false positives from floating-point
             % round-trips through JSON and cell/struct type differences.
             prevJson = ''; curJson = '';


### PR DESCRIPTION
**Problem**
**yOCTProcessTiledScan** had no way to recover from an interrupted run. If the process crashed or was stopped mid-way, whether during the per-frame parfor loop or during the final BigTIFF assembly, all partial work was discarded. The next run would start from scratch, repeating days of compute time on scans that were already done previously.


**Solution**
Added a resume option to **yOCTProcessTiledScan** and **yOCT2Tif**. This enables:

- **Per-frame skipping:** frames whose completion marker (y####.tif.json) already exists are skipped in both the pre-scan and inside the parfor loop.
- **Half-committed frame recovery:** a lone .tif without its .json (crash between the two MW1 writes) is deleted and reprocessed, so the final output is always consistent.
- **Deterministic clim:** the global contrast range is saved in _clim.json on first compute and reused on resume, preventing the final BigTIFF from changing between runs.
- **Atomic writes:** every artifact (BigTIFF, TifMetadata.json, _clim.json, reconstructConfig.json) is written to an _inProgress sibling and renamed to its final name only when 100% complete. A crash mid-write leaves no partially-named output to confuse a future resume.
- **Config guard:** on resume, the current inputs are compared against a saved reconstructConfig.json. Any mismatch (like a different focusSigma, dispersion or focus position) raises a clear and informative error before touching any data.
- **Already-done early exit:** if the final output exists and partialMode/ is gone, the function exits immediately with an error message rather than doing a no-op reprocess.
- **Resume summary:** prints "Already reconstructed / Newly reconstructed" frane counts to match the style of yOCTUnzipTiledScan.
- **16 unit tests cover all branches:** clean run, interrupted finalize, stale _inProgress BigTIFF, corrupted clim cache, half-committed frame, config mismatch (3 fields), and fully-done skip.