### PR TITLE
Create yOCTDownsizeVolume.m

### DIFF
--- a/LoadSave/yOCT2Tif.m
+++ b/LoadSave/yOCT2Tif.m
@@ -28,6 +28,7 @@ function whereAreMyFiles = yOCT2Tif (varargin)
 %       maximum of the data
 %   'metadata' - i.e. dimention structure, to be saved alongside with the data
 %       metadata is only valid at partialFileMode = 0 or 3
+%   'maxbit' - maximum bit value (default: 2^16-1). Use 2^8-1 for 8-bit
 %   'partialFileMode' - can be 0 (not active), 1, 2 or 3. If partialFileMode
 %       is 2, please set partialFileModeIndex. See partial mode below.
 %       1 - initialize
@@ -59,6 +60,7 @@ addRequired(p,'filePath',@(x)(ischar(x) | iscell(x)));
 
 addParameter(p,'clim',[])
 addParameter(p,'metadata',[])
+addParameter(p,'maxbit',[])
 addParameter(p,'partialFileMode',0);
 addParameter(p,'partialFileModeIndex',[]);
 
@@ -68,6 +70,11 @@ data = in.data;
 filePath = in.filePath;
 c = in.clim;
 metadata = in.metadata;
+maxbit = in.maxbit;
+
+if isempty(maxbit)
+    maxbit = 2^16-1;
+end
 
 % Partial Mode checks
 mode = in.partialFileMode;
@@ -176,14 +183,14 @@ if mode == 0
     end
     
     % encode meta data
-    metaJson = buildTiffVolumeMetadata(metadata,c);
+    metaJson = buildTiffVolumeMetadata(metadata,c,maxbit);
     
     if isOutputFile
         t = Tiff(outputFilePaths{1}, 'w8');  % Open Tiff file as BigTIFF
     end
 
     for yI=1:size(data,3)
-        bits = yOCT2Tif_ConvertBitsData(data(:,:,yI),c,false);
+        bits = yOCT2Tif_ConvertBitsData(data(:,:,yI),c,false,maxbit);
         
         % Save file
         if isOutputFile
@@ -191,7 +198,7 @@ if mode == 0
                 t.writeDirectory();
             end
 
-            tagstruct = buildTiffFrameTags(bits, metaJson, metadata, size(data,3));
+            tagstruct = buildTiffFrameTags(bits, metaJson, metadata, size(data,3), maxbit);
             t.setTag(tagstruct);
             t.write(bits);
         end
@@ -250,7 +257,7 @@ elseif mode == 2
     end
     
     for yI=1:size(data,3)
-        bits = yOCT2Tif_ConvertBitsData(data(:,:,yI),c,false);
+        bits = yOCT2Tif_ConvertBitsData(data(:,:,yI),c,false,maxbit);
         
         p = yScanPath(outputFilePaths{3},in.partialFileModeIndex(yI));
         
@@ -320,8 +327,8 @@ else
             tn = [tempname '.tif'];
             
             data = yOCT2Tif_ConvertBitsData(bits,...
-                [cFrameMins(frameI) cFrameMaxs(frameI)],true);
-            newBits = yOCT2Tif_ConvertBitsData(data,cStack,false);
+                [cFrameMins(frameI) cFrameMaxs(frameI)],true,maxbit);
+            newBits = yOCT2Tif_ConvertBitsData(data,cStack,false,maxbit);
 
             imwrite(newBits,tn);
             awsCopyFile_MW1(tn,fpOut); %Matlab worker version of copy files
@@ -339,7 +346,7 @@ else
     awsCopyFile_MW2(outputFilePaths{2});
     
     % Finish generating a folder by placing metadata
-    metaJson = buildTiffVolumeMetadata(metadata,c);
+    metaJson = buildTiffVolumeMetadata(metadata,c,maxbit);
     awsWriteJSON(metaJson, ...
                 [outputFilePaths{2} '/TifMetadata.json']);
     
@@ -348,7 +355,7 @@ else
     % the output TIFF slide by slide: read one frame, write it, discard it.
     % This keeps memory usage at 1 slide instead of N slides.
     if isOutputFile
-        metaJson = buildTiffVolumeMetadata(metadata, c);
+        metaJson = buildTiffVolumeMetadata(metadata, c, maxbit);
 
         % For local paths, write directly to the output to avoid filling
         % the system temp drive with a multi GB BigTIFF.
@@ -370,9 +377,9 @@ else
                 t.writeDirectory();
             end
 
-            tagstruct = buildTiffFrameTags(bits, metaJson, metadata, numberOfYPlanes);
+            tagstruct = buildTiffFrameTags(bits, metaJson, metadata, numberOfYPlanes, maxbit);
             t.setTag(tagstruct);
-            t.write(uint16(bits));
+            t.write(bits);
         end
         t.close();
 
@@ -393,23 +400,28 @@ function p = yScanPath(outputFilePaths,yIndex)
 p = awsModifyPathForCompetability(... 
     sprintf('%s/y%04d.tif', outputFilePaths,yIndex));
 
-function metaJson = buildTiffVolumeMetadata(metadata,c)
+function metaJson = buildTiffVolumeMetadata(metadata,c,maxbit)
 %  This wrapper is called once per volume before the frame loop
 meta.metadata = metadata;
 meta.clim = c;
 meta.version = 3;
+meta.maxbit = maxbit;
 metaJson = meta;
 
 %% Build TIFF tags per frame (image dimensions, compression, ImageJ resolution)
 %  This wrapper is called once per frame inside the write loop
 %  It consumes the volume metadata produced by buildTiffVolumeMetadata
-function tagstruct = buildTiffFrameTags(bits, metaJson, metadata, totalFrames)
+function tagstruct = buildTiffFrameTags(bits, metaJson, metadata, totalFrames, maxbit)
 tagstruct.ImageLength         = size(bits, 1);
 tagstruct.ImageWidth          = size(bits, 2);
 tagstruct.Photometric         = Tiff.Photometric.MinIsBlack;
 tagstruct.PlanarConfiguration = Tiff.PlanarConfiguration.Chunky;
 tagstruct.SampleFormat        = Tiff.SampleFormat.UInt;
-tagstruct.BitsPerSample       = 16;
+if maxbit <= 2^8-1
+    tagstruct.BitsPerSample   = 8;
+else
+    tagstruct.BitsPerSample   = 16;
+end
 tagstruct.Compression         = Tiff.Compression.PackBits;
 tagstruct.SamplesPerPixel     = 1;
 tagstruct.RowsPerStrip        = size(bits, 1);

--- a/LoadSave/yOCT2Tif.m
+++ b/LoadSave/yOCT2Tif.m
@@ -28,7 +28,7 @@ function whereAreMyFiles = yOCT2Tif (varargin)
 %       maximum of the data
 %   'metadata' - i.e. dimention structure, to be saved alongside with the data
 %       metadata is only valid at partialFileMode = 0 or 3
-%   'maxbit' - maximum bit value (default: 2^16-1). Use 2^8-1 for 8-bit
+%   'bitsPerSample' - bit depth (default: 16). Use 8 for 8-bit
 %   'partialFileMode' - can be 0 (not active), 1, 2 or 3. If partialFileMode
 %       is 2, please set partialFileModeIndex. See partial mode below.
 %       1 - initialize
@@ -60,7 +60,7 @@ addRequired(p,'filePath',@(x)(ischar(x) | iscell(x)));
 
 addParameter(p,'clim',[])
 addParameter(p,'metadata',[])
-addParameter(p,'maxbit',[])
+addParameter(p,'bitsPerSample',[])
 addParameter(p,'partialFileMode',0);
 addParameter(p,'partialFileModeIndex',[]);
 
@@ -70,10 +70,9 @@ data = in.data;
 filePath = in.filePath;
 c = in.clim;
 metadata = in.metadata;
-maxbit = in.maxbit;
-
-if isempty(maxbit)
-    maxbit = 2^16-1;
+bitsPerSample = in.bitsPerSample;
+if isempty(bitsPerSample)
+    bitsPerSample = 16;
 end
 
 % Partial Mode checks
@@ -183,14 +182,14 @@ if mode == 0
     end
     
     % encode meta data
-    metaJson = buildTiffVolumeMetadata(metadata,c,maxbit);
+    metaJson = buildTiffVolumeMetadata(metadata,c,bitsPerSample);
     
     if isOutputFile
         t = Tiff(outputFilePaths{1}, 'w8');  % Open Tiff file as BigTIFF
     end
 
     for yI=1:size(data,3)
-        bits = yOCT2Tif_ConvertBitsData(data(:,:,yI),c,false,maxbit);
+        bits = yOCT2Tif_ConvertBitsData(data(:,:,yI),c,false,bitsPerSample);
         
         % Save file
         if isOutputFile
@@ -198,7 +197,7 @@ if mode == 0
                 t.writeDirectory();
             end
 
-            tagstruct = buildTiffFrameTags(bits, metaJson, metadata, size(data,3), maxbit);
+            tagstruct = buildTiffFrameTags(bits, metaJson, metadata, size(data,3), bitsPerSample);
             t.setTag(tagstruct);
             t.write(bits);
         end
@@ -257,7 +256,7 @@ elseif mode == 2
     end
     
     for yI=1:size(data,3)
-        bits = yOCT2Tif_ConvertBitsData(data(:,:,yI),c,false,maxbit);
+        bits = yOCT2Tif_ConvertBitsData(data(:,:,yI),c,false,bitsPerSample);
         
         p = yScanPath(outputFilePaths{3},in.partialFileModeIndex(yI));
         
@@ -327,8 +326,8 @@ else
             tn = [tempname '.tif'];
             
             data = yOCT2Tif_ConvertBitsData(bits,...
-                [cFrameMins(frameI) cFrameMaxs(frameI)],true,maxbit);
-            newBits = yOCT2Tif_ConvertBitsData(data,cStack,false,maxbit);
+                [cFrameMins(frameI) cFrameMaxs(frameI)],true,bitsPerSample);
+            newBits = yOCT2Tif_ConvertBitsData(data,cStack,false,bitsPerSample);
 
             imwrite(newBits,tn);
             awsCopyFile_MW1(tn,fpOut); %Matlab worker version of copy files
@@ -346,7 +345,7 @@ else
     awsCopyFile_MW2(outputFilePaths{2});
     
     % Finish generating a folder by placing metadata
-    metaJson = buildTiffVolumeMetadata(metadata,c,maxbit);
+    metaJson = buildTiffVolumeMetadata(metadata,c,bitsPerSample);
     awsWriteJSON(metaJson, ...
                 [outputFilePaths{2} '/TifMetadata.json']);
     
@@ -355,7 +354,7 @@ else
     % the output TIFF slide by slide: read one frame, write it, discard it.
     % This keeps memory usage at 1 slide instead of N slides.
     if isOutputFile
-        metaJson = buildTiffVolumeMetadata(metadata, c, maxbit);
+        metaJson = buildTiffVolumeMetadata(metadata, c, bitsPerSample);
 
         % For local paths, write directly to the output to avoid filling
         % the system temp drive with a multi GB BigTIFF.
@@ -377,7 +376,7 @@ else
                 t.writeDirectory();
             end
 
-            tagstruct = buildTiffFrameTags(bits, metaJson, metadata, numberOfYPlanes, maxbit);
+            tagstruct = buildTiffFrameTags(bits, metaJson, metadata, numberOfYPlanes, bitsPerSample);
             t.setTag(tagstruct);
             t.write(bits);
         end
@@ -400,28 +399,27 @@ function p = yScanPath(outputFilePaths,yIndex)
 p = awsModifyPathForCompetability(... 
     sprintf('%s/y%04d.tif', outputFilePaths,yIndex));
 
-function metaJson = buildTiffVolumeMetadata(metadata,c,maxbit)
+function metaJson = buildTiffVolumeMetadata(metadata,c,bitsPerSample)
 %  This wrapper is called once per volume before the frame loop
 meta.metadata = metadata;
 meta.clim = c;
 meta.version = 3;
-meta.maxbit = maxbit;
+meta.bitsPerSample = bitsPerSample;
 metaJson = meta;
 
 %% Build TIFF tags per frame (image dimensions, compression, ImageJ resolution)
 %  This wrapper is called once per frame inside the write loop
 %  It consumes the volume metadata produced by buildTiffVolumeMetadata
-function tagstruct = buildTiffFrameTags(bits, metaJson, metadata, totalFrames, maxbit)
+function tagstruct = buildTiffFrameTags(bits, metaJson, metadata, totalFrames, bitsPerSample)
 tagstruct.ImageLength         = size(bits, 1);
 tagstruct.ImageWidth          = size(bits, 2);
 tagstruct.Photometric         = Tiff.Photometric.MinIsBlack;
 tagstruct.PlanarConfiguration = Tiff.PlanarConfiguration.Chunky;
 tagstruct.SampleFormat        = Tiff.SampleFormat.UInt;
-if maxbit <= 2^8-1
-    tagstruct.BitsPerSample   = 8;
-else
-    tagstruct.BitsPerSample   = 16;
+if isempty(bitsPerSample)
+    bitsPerSample = 16;
 end
+tagstruct.BitsPerSample   = bitsPerSample;
 tagstruct.Compression         = Tiff.Compression.PackBits;
 tagstruct.SamplesPerPixel     = 1;
 tagstruct.RowsPerStrip        = size(bits, 1);

--- a/LoadSave/yOCT2Tif_ConvertBitsData.m
+++ b/LoadSave/yOCT2Tif_ConvertBitsData.m
@@ -9,6 +9,15 @@ if ~exist('bitsPerSample','var') || isempty(bitsPerSample)
     bitsPerSample = 16;
 end
 
+if bitsPerSample <= 8
+    outputClass = 'uint8';
+elseif bitsPerSample <= 16
+    outputClass = 'uint16';
+else
+    error('yOCT2Tif_ConvertBitsData:UnsupportedBits', ...
+        'bitsPerSample > 16 is not supported.');
+end
+
 maxValue = 2^bitsPerSample-1;
 
 %% Conversion
@@ -18,10 +27,6 @@ if isInputBits
     out(in==0) = NaN;
 else
     % Data -> Bits
-    if bitsPerSample <= 8
-        out = uint8((squeeze(in)-c(1))/(c(2)-c(1))*(maxValue-1))+1;
-    else
-        out = uint16((squeeze(in)-c(1))/(c(2)-c(1))*(maxValue-1))+1;
-    end
+    out = feval(outputClass, (squeeze(in)-c(1))/(c(2)-c(1))*(maxValue-1)) + 1;
     out(isnan(in)) = 0; %NaN is reserved for 0
 end

--- a/LoadSave/yOCT2Tif_ConvertBitsData.m
+++ b/LoadSave/yOCT2Tif_ConvertBitsData.m
@@ -16,6 +16,10 @@ if isInputBits
     out(in==0) = NaN;
 else
     % Data -> Bits
-    out = uint16((squeeze(in)-c(1))/(c(2)-c(1))*(maxbit-1))+1;
+    if maxbit <= 2^8-1
+        out = uint8((squeeze(in)-c(1))/(c(2)-c(1))*(maxbit-1))+1;
+    else
+        out = uint16((squeeze(in)-c(1))/(c(2)-c(1))*(maxbit-1))+1;
+    end
     out(isnan(in)) = 0; %NaN is reserved for 0
 end

--- a/LoadSave/yOCT2Tif_ConvertBitsData.m
+++ b/LoadSave/yOCT2Tif_ConvertBitsData.m
@@ -1,25 +1,27 @@
-function out = yOCT2Tif_ConvertBitsData(in, c, isInputBits, maxbit)
+function out = yOCT2Tif_ConvertBitsData(in, c, isInputBits, bitsPerSample)
 % isInputBits - when set to true will convert bits -> data
 %                           false     convert data -> bits
 
 %% Input
 c = sort(c);
 
-if ~exist('maxbit','var') || isempty(maxbit)
-    maxbit = 2^16-1;
+if ~exist('bitsPerSample','var') || isempty(bitsPerSample)
+    bitsPerSample = 16;
 end
+
+maxValue = 2^bitsPerSample-1;
 
 %% Conversion
 if isInputBits
     % Bits -> Data
-    out = double(in-1)*(c(2)-c(1))/(maxbit-1)+c(1);
+    out = double(in-1)*(c(2)-c(1))/(maxValue-1)+c(1);
     out(in==0) = NaN;
 else
     % Data -> Bits
-    if maxbit <= 2^8-1
-        out = uint8((squeeze(in)-c(1))/(c(2)-c(1))*(maxbit-1))+1;
+    if bitsPerSample <= 8
+        out = uint8((squeeze(in)-c(1))/(c(2)-c(1))*(maxValue-1))+1;
     else
-        out = uint16((squeeze(in)-c(1))/(c(2)-c(1))*(maxbit-1))+1;
+        out = uint16((squeeze(in)-c(1))/(c(2)-c(1))*(maxValue-1))+1;
     end
     out(isnan(in)) = 0; %NaN is reserved for 0
 end

--- a/LoadSave/yOCTFromTif.m
+++ b/LoadSave/yOCTFromTif.m
@@ -113,11 +113,7 @@ if (isInputFile)
     else    
         description = '';  % No MetaData available
     end
-    bitsPerSampleDefault = [];
-    if isfield(info(1),'BitsPerSample') && ~isempty(info(1).BitsPerSample)
-        bitsPerSampleDefault = info(1).BitsPerSample;
-    end
-    [c, metadata, bitsPerSample] = intrpertDescription(description,filepath,bitsPerSampleDefault);
+    [c, metadata, bitsPerSample] = intrpertDescription(description, info, filepath);
     
     if isempty(yI) || isCheckMetadata
         % Get avilable Ys
@@ -132,7 +128,7 @@ else
     % Read meta from JSON
     description = awsReadJSON([filepath '/TifMetadata.json']);
     
-    [c, metadata, bitsPerSample] = intrpertDescription(description,filepath,[]);
+    [c, metadata, bitsPerSample] = intrpertDescription(description, [], filepath);
     
     if isempty(yI) || isCheckMetadata
         % Get avilable Ys
@@ -253,10 +249,13 @@ copyfile(filepath,out);
 
 end
 
-function [c, metaData, bitsPerSample] = intrpertDescription(description,filepath,bitsPerSampleDefault)
+function [c, metaData, bitsPerSample] = intrpertDescription(description, info, filepath)
 
-if ~exist('bitsPerSampleDefault','var')
-    bitsPerSampleDefault = [];
+bitsPerSampleDefault = [];
+if exist('info','var') && ~isempty(info)
+    if isfield(info(1),'BitsPerSample') && ~isempty(info(1).BitsPerSample)
+        bitsPerSampleDefault = info(1).BitsPerSample;
+    end
 end
 
 if isempty(description)

--- a/LoadSave/yOCTFromTif.m
+++ b/LoadSave/yOCTFromTif.m
@@ -52,10 +52,6 @@ else
     isAWS = false;
 end
 
-end
-
-end
-
 %% Is Tif Folder or File
 [~,~,f] = fileparts(filepath);
     

--- a/LoadSave/yOCTFromTif.m
+++ b/LoadSave/yOCTFromTif.m
@@ -338,3 +338,5 @@ end
 
 end
 
+end
+

--- a/LoadSave/yOCTFromTif.m
+++ b/LoadSave/yOCTFromTif.m
@@ -243,11 +243,15 @@ for i=1:length(yI)
     
     data(:,:,i) = yOCT2Tif_ConvertBitsData(bits,c,true,bitsPerSample); %Rescale to the original values
 end
-    
+
+end
+
 function out = copyFileLocally(filepath)
 %Copy filename to other temp name
 out = [tempname '.tif'];
 copyfile(filepath,out);
+
+end
 
 function [c, metaData, bitsPerSample] = intrpertDescription(description,filepath,bitsPerSampleDefault)
 

--- a/LoadSave/yOCTFromTif.m
+++ b/LoadSave/yOCTFromTif.m
@@ -52,6 +52,10 @@ else
     isAWS = false;
 end
 
+end
+
+end
+
 %% Is Tif Folder or File
 [~,~,f] = fileparts(filepath);
     

--- a/LoadSave/yOCTFromTif.m
+++ b/LoadSave/yOCTFromTif.m
@@ -113,7 +113,11 @@ if (isInputFile)
     else    
         description = '';  % No MetaData available
     end
-    [c, metadata, maxbit] = intrpertDescription(description,filepath);
+    bitsPerSampleDefault = 8;
+    if isfield(info(1),'BitsPerSample') && ~isempty(info(1).BitsPerSample)
+        bitsPerSampleDefault = info(1).BitsPerSample;
+    end
+    [c, metadata, bitsPerSample] = intrpertDescription(description,filepath,bitsPerSampleDefault);
     
     if isempty(yI) || isCheckMetadata
         % Get avilable Ys
@@ -128,7 +132,8 @@ else
     % Read meta from JSON
     description = awsReadJSON([filepath '/TifMetadata.json']);
     
-    [c, metadata, maxbit] = intrpertDescription(description,filepath);
+    bitsPerSampleDefault = 8;
+    [c, metadata, bitsPerSample] = intrpertDescription(description,filepath,bitsPerSampleDefault);
     
     if isempty(yI) || isCheckMetadata
         % Get avilable Ys
@@ -144,8 +149,9 @@ else
 end 
 
 %No Scaling information, use default
+maxValue = 2^bitsPerSample-1;
 if isempty(c) || length(c)~=2
-    c(1) = maxbit;
+    c(1) = maxValue;
     c(2) = 0;
 end
 
@@ -236,7 +242,7 @@ for i=1:length(yI)
         data = zeros(size(bits,1),size(bits,2),length(yI),'single');
     end
     
-    data(:,:,i) = yOCT2Tif_ConvertBitsData(bits,c,true,maxbit); %Rescale to the original values
+    data(:,:,i) = yOCT2Tif_ConvertBitsData(bits,c,true,bitsPerSample); %Rescale to the original values
 end
     
 function out = copyFileLocally(filepath)
@@ -244,12 +250,12 @@ function out = copyFileLocally(filepath)
 out = [tempname '.tif'];
 copyfile(filepath,out);
 
-function [c, metaData, maxbit] = intrpertDescription(description,filepath)
+function [c, metaData, bitsPerSample] = intrpertDescription(description,filepath,bitsPerSampleDefault)
 
 if isempty(description)
     c = [];
     metaData = [];
-    maxbit = 2^8-1;
+    bitsPerSample = bitsPerSampleDefault;
     return;
 end
 
@@ -260,7 +266,7 @@ if (~isstruct(description) && description(1) ~= '{')
     c = sscanf(description,'min:%g,max:%g');
     isDepricatedVersion = true;
     metaData = [];
-    maxbit = 2^8-1;
+    bitsPerSample = bitsPerSampleDefault;
 else
     if ~isstruct(description)
         jsn = jsondecode(description);
@@ -272,15 +278,15 @@ else
         metaData = jsn.dim;
         c = jsn.c;
         isDepricatedVersion = true;
-        maxbit = 2^8-1;
+        bitsPerSample = bitsPerSampleDefault;
     elseif (jsn.version == 3)
         % Good version
         metaData = jsn.metadata;
         c = jsn.clim;
-        if isfield(jsn,'maxbit') && ~isempty(jsn.maxbit)
-            maxbit = jsn.maxbit;
+        if isfield(jsn,'bitsPerSample') && ~isempty(jsn.bitsPerSample)
+            bitsPerSample = jsn.bitsPerSample;
         else
-            maxbit = []; %Latest version
+            bitsPerSample = bitsPerSampleDefault;
         end
     end
 end

--- a/LoadSave/yOCTFromTif.m
+++ b/LoadSave/yOCTFromTif.m
@@ -113,7 +113,7 @@ if (isInputFile)
     else    
         description = '';  % No MetaData available
     end
-    bitsPerSampleDefault = 8;
+    bitsPerSampleDefault = [];
     if isfield(info(1),'BitsPerSample') && ~isempty(info(1).BitsPerSample)
         bitsPerSampleDefault = info(1).BitsPerSample;
     end
@@ -132,8 +132,7 @@ else
     % Read meta from JSON
     description = awsReadJSON([filepath '/TifMetadata.json']);
     
-    bitsPerSampleDefault = 8;
-    [c, metadata, bitsPerSample] = intrpertDescription(description,filepath,bitsPerSampleDefault);
+    [c, metadata, bitsPerSample] = intrpertDescription(description,filepath,[]);
     
     if isempty(yI) || isCheckMetadata
         % Get avilable Ys
@@ -252,10 +251,14 @@ copyfile(filepath,out);
 
 function [c, metaData, bitsPerSample] = intrpertDescription(description,filepath,bitsPerSampleDefault)
 
+if ~exist('bitsPerSampleDefault','var')
+    bitsPerSampleDefault = [];
+end
+
 if isempty(description)
     c = [];
     metaData = [];
-    bitsPerSample = bitsPerSampleDefault;
+    bitsPerSample = 8;
     return;
 end
 
@@ -266,7 +269,7 @@ if (~isstruct(description) && description(1) ~= '{')
     c = sscanf(description,'min:%g,max:%g');
     isDepricatedVersion = true;
     metaData = [];
-    bitsPerSample = bitsPerSampleDefault;
+    bitsPerSample = 8;
 else
     if ~isstruct(description)
         jsn = jsondecode(description);
@@ -278,13 +281,13 @@ else
         metaData = jsn.dim;
         c = jsn.c;
         isDepricatedVersion = true;
-        bitsPerSample = bitsPerSampleDefault;
+        bitsPerSample = 8;
     elseif (jsn.version == 3)
         % Good version
         metaData = jsn.metadata;
         c = jsn.clim;
-        if isfield(jsn,'bitsPerSample') && ~isempty(jsn.bitsPerSample)
-            bitsPerSample = jsn.bitsPerSample;
+        if isempty(bitsPerSampleDefault)
+            bitsPerSample = 16;
         else
             bitsPerSample = bitsPerSampleDefault;
         end
@@ -302,6 +305,8 @@ if isDepricatedVersion && (isempty(timeOfLastWarningHappend) || ...
         'yOCT2Tif(data, filePath, ''metadata'', meta);'],filepath,filepath);
     
     timeOfLastWarningHappend = now;
+end
+
 end
 
 function im = imreadWrapper(imagePath, frameIndex, pixRegionX, pixRegionY)
@@ -326,3 +331,6 @@ if (size(im,3) ~= 1)
     end
     im = squeeze(im(:,:,1));
 end
+
+end
+

--- a/LoadSave/yOCTFromTif.m
+++ b/LoadSave/yOCTFromTif.m
@@ -277,7 +277,11 @@ else
         % Good version
         metaData = jsn.metadata;
         c = jsn.clim;
-        maxbit = []; %Latest version
+        if isfield(jsn,'maxbit') && ~isempty(jsn.maxbit)
+            maxbit = jsn.maxbit;
+        else
+            maxbit = []; %Latest version
+        end
     end
 end
 

--- a/Processing/test_yOCTDownsizeVolume.m
+++ b/Processing/test_yOCTDownsizeVolume.m
@@ -1,0 +1,63 @@
+classdef test_yOCTDownsizeVolume < matlab.unittest.TestCase
+    properties
+        TestFolder
+        InputFile
+        OutputFile
+    end
+
+    methods(TestMethodSetup)
+        function createFolders(testCase)
+            testCase.TestFolder = fullfile(pwd, 'downsize_volume_tester');
+            if exist(testCase.TestFolder, 'dir')
+                rmdir(testCase.TestFolder, 's');
+            end
+            mkdir(testCase.TestFolder);
+
+            testCase.InputFile = fullfile(testCase.TestFolder, 'input.tif');
+            testCase.OutputFile = fullfile(testCase.TestFolder, 'output.tif');
+        end
+    end
+
+    methods(TestMethodTeardown)
+        function removeTestFolder(testCase)
+            if exist(testCase.TestFolder, 'dir')
+                rmdir(testCase.TestFolder, 's');
+            end
+        end
+    end
+
+    methods(Test)
+        function testDownsizeFactorTwo(testCase)
+            % Create a small deterministic volume: (z,x,y)
+            data = reshape(linspace(0, 1, 4 * 6 * 8), [4, 6, 8]);
+
+            meta.x.values = 1:6;
+            meta.x.index = 1:6;
+            meta.y.values = 1:8;
+            meta.y.index = 1:8;
+            meta.z.values = 1:4;
+            meta.z.index = 1:4;
+
+            yOCT2Tif(data, testCase.InputFile, 'metadata', meta);
+
+            yOCTDownsizeVolume(testCase.InputFile, testCase.OutputFile, 2);
+
+            xI = 1:2:6;
+            yI = 1:2:8;
+            zI = 1:2:4;
+
+            expected = yOCTFromTif(testCase.InputFile, 'xI', xI, 'yI', yI, 'zI', zI);
+            actual = yOCTFromTif(testCase.OutputFile);
+
+            testCase.assertEqual(size(actual), size(expected), 'Output size mismatch');
+
+            maxDiff = max(abs(actual(:) - expected(:)));
+            testCase.assertLessThanOrEqual(maxDiff, 1 / 255, 'Downsized data mismatch');
+
+            [~, metaOut] = yOCTFromTif(testCase.OutputFile, 'isLoadMetadataOnly', true);
+            testCase.assertEqual(length(metaOut.x.index), numel(xI), 'x metadata size mismatch');
+            testCase.assertEqual(length(metaOut.y.index), numel(yI), 'y metadata size mismatch');
+            testCase.assertEqual(length(metaOut.z.index), numel(zI), 'z metadata size mismatch');
+        end
+    end
+end

--- a/Processing/test_yOCTDownsizeVolume.m
+++ b/Processing/test_yOCTDownsizeVolume.m
@@ -31,12 +31,15 @@ classdef test_yOCTDownsizeVolume < matlab.unittest.TestCase
             % Create a small deterministic volume: (z,x,y)
             data = reshape(linspace(0, 1, 4 * 6 * 8), [4, 6, 8]);
 
-            meta.x.values = 1:6;
+            meta.x.values = (1:6) * 1e-6;
             meta.x.index = 1:6;
-            meta.y.values = 1:8;
+            meta.x.units = 'meters';
+            meta.y.values = (1:8) * 1e-6;
             meta.y.index = 1:8;
-            meta.z.values = 1:4;
+            meta.y.units = 'meters';
+            meta.z.values = (1:4) * 1e-6;
             meta.z.index = 1:4;
+            meta.z.units = 'meters';
 
             yOCT2Tif(data, testCase.InputFile, 'metadata', meta);
 

--- a/Processing/yOCTDownsizeVolume.m
+++ b/Processing/yOCTDownsizeVolume.m
@@ -66,7 +66,7 @@ if isstruct(metadata) && isfield(metadata,'x') && isfield(metadata,'y') && isfie
     metadataOut.y.index = 1:length(yI);
     metadataOut.z.values = metadata.z.values(zI);
     metadataOut.z.index = 1:length(zI);
-    yOCT2Tif(volumeOut, outputPath, 'metadata', metadataOut, 'clim', c, 'maxbit', 2^8-1);
+    yOCT2Tif(volumeOut, outputPath, 'metadata', metadataOut, 'clim', c, 'bitsPerSample', 8);
 else
     error('Missing metadata in tif header. Cannot update metadata for output.');
 end

--- a/Processing/yOCTDownsizeVolume.m
+++ b/Processing/yOCTDownsizeVolume.m
@@ -1,10 +1,10 @@
 function [] = yOCTDownsizeVolume(volumePath, outputPath, downsampleFactor)
 % This function downsamples a tif volume by taking every Nth sample and
-% saves the result to a new tif with updated metadata.
+% saves the result to a new 8-bit tif with updated metadata.
 %
 % INPUTS:
 %   volumePath      - tif file or tif stack folder path
-%   outputPath      - tif file or tif stack folder path to save output
+%   outputPath      - tif file path to save output
 %   downsampleFactor - scalar or 3-element vector [z x y] (default: 5)
 %
 % OUTPUTS:
@@ -20,6 +20,11 @@ end
 
 if ~(ischar(outputPath) || isstring(outputPath))
     error('outputPath must be a tif file or tif folder path.');
+end
+
+[~,~,ext] = fileparts(char(outputPath));
+if isempty(ext)
+    error('outputPath must be a tif file path (not a folder).');
 end
 
 downsizeFromTif(volumePath, outputPath, downsampleFactor);
@@ -61,7 +66,7 @@ if isstruct(metadata) && isfield(metadata,'x') && isfield(metadata,'y') && isfie
     metadataOut.y.index = 1:length(yI);
     metadataOut.z.values = metadata.z.values(zI);
     metadataOut.z.index = 1:length(zI);
-    yOCT2Tif(volumeOut, outputPath, 'metadata', metadataOut, 'clim', c);
+    yOCT2Tif(volumeOut, outputPath, 'metadata', metadataOut, 'clim', c, 'maxbit', 2^8-1);
 else
     error('Missing metadata in tif header. Cannot update metadata for output.');
 end

--- a/Processing/yOCTDownsizeVolume.m
+++ b/Processing/yOCTDownsizeVolume.m
@@ -1,13 +1,14 @@
-function volumeOut = yOCTDownsizeVolume(volumePath, downsampleFactor)
-% This function downsamples a tif volume by taking every Nth sample.
-%
-% USAGE:
-%   volumeOut = yOCTDownsizeVolume(volumePath, downsampleFactor)
+function [] = yOCTDownsizeVolume(volumePath, outputPath, downsampleFactor)
+% This function downsamples a tif volume by taking every Nth sample and
+% saves the result to a new tif with updated metadata.
 %
 % INPUTS:
-%   volumePath - tif file or tif stack folder path
-%   downsampleFactor - scalar or vector with one factor per dimension
-%       default is 5
+%   volumePath      - tif file or tif stack folder path
+%   outputPath      - tif file or tif stack folder path to save output
+%   downsampleFactor - scalar or 3-element vector [z x y] (default: 5)
+%
+% OUTPUTS:
+%   none
 
 if ~exist('downsampleFactor','var') || isempty(downsampleFactor)
     downsampleFactor = 5;
@@ -17,12 +18,17 @@ if ~(ischar(volumePath) || isstring(volumePath))
     error('volumePath must be a tif file or tif folder path.');
 end
 
-volumeOut = downsizeFromTif(volumePath, downsampleFactor);
+if ~(ischar(outputPath) || isstring(outputPath))
+    error('outputPath must be a tif file or tif folder path.');
+end
+
+downsizeFromTif(volumePath, outputPath, downsampleFactor);
 
 end
 
-function volumeOut = downsizeFromTif(filepath, downsampleFactor)
+function [] = downsizeFromTif(filepath, outputPath, downsampleFactor)
 filepath = char(filepath);
+outputPath = char(outputPath);
 
 if isscalar(downsampleFactor)
     downsampleFactor = repmat(downsampleFactor, 1, 3);
@@ -47,31 +53,18 @@ if isstruct(metadata) && isfield(metadata,'x') && isfield(metadata,'y') && isfie
     yI = 1:downsampleFactor(3):ny;
     zI = 1:downsampleFactor(1):nz;
 
-    volumeOut = yOCTFromTif(filepath, 'xI', xI, 'yI', yI, 'zI', zI);
+    [volumeOut, ~, c] = yOCTFromTif(filepath, 'xI', xI, 'yI', yI, 'zI', zI);
+    metadataOut = metadata;
+    metadataOut.x.values = metadata.x.values(xI);
+    metadataOut.x.index = 1:length(xI);
+    metadataOut.y.values = metadata.y.values(yI);
+    metadataOut.y.index = 1:length(yI);
+    metadataOut.z.values = metadata.z.values(zI);
+    metadataOut.z.index = 1:length(zI);
+    yOCT2Tif(volumeOut, outputPath, 'metadata', metadataOut, 'clim', c);
 else
-    data = yOCTFromTif(filepath);
-    volumeOut = downsizeNumericVolume(data, downsampleFactor);
+    error('Missing metadata in tif header. Cannot update metadata for output.');
 end
 
 end
-
-function volumeOut = downsizeNumericVolume(volumeIn, downsampleFactor)
-if isscalar(downsampleFactor)
-    downsampleFactor = repmat(downsampleFactor, 1, ndims(volumeIn));
-end
-
-if numel(downsampleFactor) ~= ndims(volumeIn)
-    error('downsampleFactor must be scalar or match number of dimensions.');
-end
-
-if any(downsampleFactor < 1) || any(mod(downsampleFactor,1) ~= 0)
-    error('downsampleFactor must contain positive integers.');
-end
-
-idx = cell(1, ndims(volumeIn));
-for d = 1:ndims(volumeIn)
-    idx{d} = 1:downsampleFactor(d):size(volumeIn, d);
-end
-
-volumeOut = volumeIn(idx{:});
 

--- a/Processing/yOCTDownsizeVolume.m
+++ b/Processing/yOCTDownsizeVolume.m
@@ -1,0 +1,77 @@
+function volumeOut = yOCTDownsizeVolume(volumePath, downsampleFactor)
+% This function downsamples a tif volume by taking every Nth sample.
+%
+% USAGE:
+%   volumeOut = yOCTDownsizeVolume(volumePath, downsampleFactor)
+%
+% INPUTS:
+%   volumePath - tif file or tif stack folder path
+%   downsampleFactor - scalar or vector with one factor per dimension
+%       default is 5
+
+if ~exist('downsampleFactor','var') || isempty(downsampleFactor)
+    downsampleFactor = 5;
+end
+
+if ~(ischar(volumePath) || isstring(volumePath))
+    error('volumePath must be a tif file or tif folder path.');
+end
+
+volumeOut = downsizeFromTif(volumePath, downsampleFactor);
+
+end
+
+function volumeOut = downsizeFromTif(filepath, downsampleFactor)
+filepath = char(filepath);
+
+if isscalar(downsampleFactor)
+    downsampleFactor = repmat(downsampleFactor, 1, 3);
+end
+
+if numel(downsampleFactor) ~= 3
+    error('downsampleFactor must be scalar or a 3-element vector for tif data.');
+end
+
+if any(downsampleFactor < 1) || any(mod(downsampleFactor,1) ~= 0)
+    error('downsampleFactor must contain positive integers.');
+end
+
+[~, metadata] = yOCTFromTif(filepath, 'isLoadMetadataOnly', true);
+
+if isstruct(metadata) && isfield(metadata,'x') && isfield(metadata,'y') && isfield(metadata,'z')
+    nx = length(metadata.x.index);
+    ny = length(metadata.y.index);
+    nz = length(metadata.z.index);
+
+    xI = 1:downsampleFactor(2):nx;
+    yI = 1:downsampleFactor(3):ny;
+    zI = 1:downsampleFactor(1):nz;
+
+    volumeOut = yOCTFromTif(filepath, 'xI', xI, 'yI', yI, 'zI', zI);
+else
+    data = yOCTFromTif(filepath);
+    volumeOut = downsizeNumericVolume(data, downsampleFactor);
+end
+
+end
+
+function volumeOut = downsizeNumericVolume(volumeIn, downsampleFactor)
+if isscalar(downsampleFactor)
+    downsampleFactor = repmat(downsampleFactor, 1, ndims(volumeIn));
+end
+
+if numel(downsampleFactor) ~= ndims(volumeIn)
+    error('downsampleFactor must be scalar or match number of dimensions.');
+end
+
+if any(downsampleFactor < 1) || any(mod(downsampleFactor,1) ~= 0)
+    error('downsampleFactor must contain positive integers.');
+end
+
+idx = cell(1, ndims(volumeIn));
+for d = 1:ndims(volumeIn)
+    idx{d} = 1:downsampleFactor(d):size(volumeIn, d);
+end
+
+volumeOut = volumeIn(idx{:});
+


### PR DESCRIPTION
Current Situation:

- Smitha has a hard time loading big files

Fix:

- Initial function for down sampling images
- Inputs are a tif file, output path, and down sample factor, where user can specify the factor, default is 5
- uses yOCTtoTif to preserve metadata
- Saves to specified output path

Test:

- New test created
- Verified work with live data