### PR TITLE
Fix galvo phase delay at low resolution in optical path correction

### DIFF
--- a/Processing/test_yOCTProcessTiledScan_createDimStructure.m
+++ b/Processing/test_yOCTProcessTiledScan_createDimStructure.m
@@ -1,0 +1,158 @@
+classdef test_yOCTProcessTiledScan_createDimStructure < matlab.unittest.TestCase
+    % Tests for the galvo phase delay X-correction in yOCTProcessTiledScan_createDimStructure.
+    %
+    %   At low pixel resolutions the galvo mirror lags behind the commanded
+    %   position, so the X coordinates written in the OCT file are wrong.
+    %   yOCTProcessTiledScan_createDimStructure fixes this by shifting
+    %   dimOneTile.x.values by N*(pixelSize_um - 1)*1e-3 mm, where N is
+    %   the GalvoPhaseDelay_Asamples value stored in the probe .ini file.
+    %   After this shift every downstream function (optical path correction,
+    %   tile stitching, surface detection) automatically receives the
+    %   correct physical beam positions.
+    %
+    %   Each test creates a simulated scan on disk, sets the desired
+    %   parameters in ScanInfo.json, calls createDimStructure, and checks
+    %   that x.values came out with the expected values.
+
+    methods(TestClassSetup)
+        function setupHardwareLib(~)
+            yOCTHardware('init', 'OCTSystem', 'Ganymede', 'skipHardware', true);
+        end
+    end
+
+    properties (Access = private)
+        TestFolder = 'tmp_galvo_phase_delay_test/'
+    end
+
+    methods (Access = private)
+        function simulateScan(testCase, nXPixels, pixelSize_um, galvoPhaseDelay_Asamples)
+            % Creates a simulated tile scan folder on disk with the given pixel
+            % size and number of X columns. If galvoPhaseDelay_Asamples is
+            % non-zero it is written into ScanInfo.json so that
+            % createDimStructure can read and apply it.
+            % Pass galvoPhaseDelay_Asamples = 0 to leave the field absent.
+
+            if exist(testCase.TestFolder, 'dir')
+                rmdir(testCase.TestFolder, 's');
+            end
+            dummyData = zeros(512, nXPixels, 2) + 1;
+            octProbePath = yOCTGetProbeIniPath('20x', 'OCTG', '');
+            yOCTSimulateTileScan(dummyData, testCase.TestFolder, ...
+                'pixelSize_um', pixelSize_um, ...
+                'zDepths', 0, ...
+                'focusPositionInImageZpix', 250, ...
+                'focusSigma', 1, ...
+                'octProbePath', octProbePath);
+
+            if galvoPhaseDelay_Asamples ~= 0
+                json = awsReadJSON([testCase.TestFolder 'ScanInfo.json']);
+                json.octProbe.GalvoPhaseDelay_Asamples = galvoPhaseDelay_Asamples;
+                awsWriteJSON(json, [testCase.TestFolder 'ScanInfo.json']);
+            end
+        end
+
+        function x_mm = uncorrectedXFromJson(~, json)
+            % Returns what x.values would be if NO galvo correction were
+            % applied, like the raw commanded positions from the JSON.
+            % Used as the reference baseline in each test.
+            x_mm = json.xOffset + ...
+                json.tileRangeX_mm * linspace(-0.5, 0.5, json.nXPixelsInEachTile + 1);
+            x_mm(end) = [];
+        end
+
+        function cleanup(testCase)
+            if exist(testCase.TestFolder, 'dir')
+                rmdir(testCase.TestFolder, 's');
+            end
+        end
+    end
+
+    methods(Test)
+        function testNoOpAtCalibrationPixelSize(testCase)
+            % The correction formula is N*(pixelSize - 1um). At 1 um/pixel
+            % (the resolution where the probe polynomial was calibrated)
+            % this evaluates to N*(1-1) = 0 regardless of N. So x.values
+            % must be identical to the raw commanded positions. The fix
+            % must be a complete no operation at high resolution.
+
+            testCase.simulateScan(500, 1, 15.5);
+            testCase.addTeardown(@() testCase.cleanup());
+
+            [dimOneTile, ~] = yOCTProcessTiledScan_createDimStructure(testCase.TestFolder);
+            json = awsReadJSON([testCase.TestFolder 'ScanInfo.json']);
+
+            testCase.verifyEqual(dimOneTile.x.values, testCase.uncorrectedXFromJson(json), ...
+                'AbsTol', 1e-9, ...
+                'At calibration pixel size the correction must be a no operation done');
+        end
+
+        function testCorrectShiftAtLowResolution(testCase)
+            % At low resolution the galvo lag in microns is large. This
+            % test uses the real calibrated value for the 20x OCTG probe:
+            % N = 15.5 samples at 20 um/pixel => shift = 15.5*(20-1)*1e-3
+            % = 0.2945 mm. It checks three things:
+            %   1. dimOneTile.x.values shifted by exactly 0.2945 mm.
+            %   2. dimOutput.x.values (the full-volume grid) inherited the
+            %      same shift so tile stitching is also correct.
+            %   3. The spacing between adjacent x values did NOT change:
+            %      a constant shift must never affect pixel size.
+
+            pixelSize_um = 20;
+            N = 15.5;
+            testCase.simulateScan(24, pixelSize_um, N);
+            testCase.addTeardown(@() testCase.cleanup());
+
+            [dimOneTile, dimOutput] = yOCTProcessTiledScan_createDimStructure(testCase.TestFolder);
+            json = awsReadJSON([testCase.TestFolder 'ScanInfo.json']);
+
+            calibrationPixelSize_um = 1;
+            expectedShift_mm = N * (pixelSize_um - calibrationPixelSize_um) * 1e-3;
+            uncorrected = testCase.uncorrectedXFromJson(json);
+            expected = uncorrected - expectedShift_mm;
+
+            testCase.verifyEqual(dimOneTile.x.values, expected, ...
+                'AbsTol', 1e-9, ...
+                'Per-tile X must shift by N*(dx-1)*1e-3 mm');
+
+            % Global output X inherits the same shift (single-tile test).
+            testCase.verifyEqual(dimOutput.x.values(1) - uncorrected(1), -expectedShift_mm, ...
+                'AbsTol', 1e-9, ...
+                'Global output X must inherit the correction');
+
+            % Constant subtraction must not change pixel spacing.
+            testCase.verifyEqual(diff(dimOneTile.x.values), diff(uncorrected), ...
+                'AbsTol', 1e-12, 'Pixel spacing must be unchanged');
+        end
+
+        function testBackwardsCompatibleNoField(testCase)
+            % Probes that have never been galvo-delay calibrated do not have 
+            % GalvoPhaseDelay_Asamples in their .ini file, so the field will
+            % be absent from ScanInfo.json. In that case the correction must
+            % default to zero: existing scans from these probes must be completely 
+            % unaffected by this change.
+
+            % The 20x OCTG .ini already has the field, so after simulating
+            % we manually remove it from ScanInfo.json to replicate what
+            % an uncalibrated probe scan looks like on disk:
+            testCase.simulateScan(24, 20, 0);
+            testCase.addTeardown(@() testCase.cleanup());
+
+            % Remove the field to simulate an uncalibrated probe
+            json = awsReadJSON([testCase.TestFolder 'ScanInfo.json']);
+            json.octProbe = rmfield(json.octProbe, 'GalvoPhaseDelay_Asamples');
+            awsWriteJSON(json, [testCase.TestFolder 'ScanInfo.json']);
+
+            [dimOneTile, ~] = yOCTProcessTiledScan_createDimStructure(testCase.TestFolder);
+            json = awsReadJSON([testCase.TestFolder 'ScanInfo.json']);
+
+            % Confirm the field is really gone before checking x.values
+            testCase.verifyFalse( ...
+                isfield(json.octProbe, 'GalvoPhaseDelay_Asamples'), ...
+                'Precondition: field must have been removed from ScanInfo.json');
+
+            testCase.verifyEqual(dimOneTile.x.values, testCase.uncorrectedXFromJson(json), ...
+                'AbsTol', 1e-9, ...
+                'Without GalvoPhaseDelay_Asamples there must be no shift');
+        end
+    end
+end

--- a/Processing/yOCTOpticalPathCorrection.m
+++ b/Processing/yOCTOpticalPathCorrection.m
@@ -50,14 +50,26 @@ if strcmpi(inputScanDimensions.x.units, 'na') || ...
 end
 
 %% Extract optical path polynomial from opticalPathCorrectionOptions
+% galvoPhaseDelay_Asamples (N) compensates for the galvo's mechanical lag:
+% the physical beam position lags the commanded position by N A-scan
+% samples. The polynomial is calibrated at calibrationPixelSize_um, so the
+% net shift to apply at runtime is N*(dx - calibrationPixelSize_um).
+calibrationPixelSize_um = 1; % Pixel size used when fitting OpticalPathCorrectionPolynomial
+galvoPhaseDelay_Asamples = 0; % Default: no compensation (backwards compatible)
 if isstruct(opticalPathCorrectionOptions)
     OP_p = opticalPathCorrectionOptions.octProbe.OpticalPathCorrectionPolynomial;
     OP_p = OP_p(:)';
+    if isfield(opticalPathCorrectionOptions.octProbe, 'GalvoPhaseDelay_Asamples')
+        galvoPhaseDelay_Asamples = opticalPathCorrectionOptions.octProbe.GalvoPhaseDelay_Asamples;
+    end
 elseif isstring(opticalPathCorrectionOptions)
     inputVolumeFolder = awsModifyPathForCompetability([opticalPathCorrectionOptions '/']);
     json = awsReadJSON([inputVolumeFolder 'ScanInfo.json']);
     OP_p = json.octProbe.OpticalPathCorrectionPolynomial;
     OP_p = OP_p(:)';
+    if isfield(json.octProbe, 'GalvoPhaseDelay_Asamples')
+        galvoPhaseDelay_Asamples = json.octProbe.GalvoPhaseDelay_Asamples;
+    end
 elseif ismatrix(opticalPathCorrectionOptions)
     if not(isequal(size(opticalPathCorrectionOptions), [1,5])) && not(isequal(size(opticalPathCorrectionOptions), [5,1]))
         error('Optical path correction polynomial must have 5 terms')
@@ -73,15 +85,26 @@ correctedScan = zeros(size(inputScan));
 %% Change dimensions to microns units
 inputScanDimensions = yOCTChangeDimensionsStructureUnits(inputScanDimensions,'microns');
 
-%% Iterate through the inputScan volume and apply optical path correction to each individual scan 
+%% Compute galvo lag spatial shift (only along fast x-axis; y-axis is slow)
+xValues_um = inputScanDimensions.x.values;
+if length(xValues_um) > 1
+    dx_um = mean(diff(xValues_um));
+else
+    dx_um = calibrationPixelSize_um;
+end
+xShift_um = galvoPhaseDelay_Asamples * (dx_um - calibrationPixelSize_um);
+
+%% Iterate through the inputScan volume and apply optical path correction to each individual scan
 for i=1:size(inputScan,3)
-    
+
     % Extract B-scan from volume
     scan = squeeze(inputScan(:,:,i));
-    
+
     %Lens abberation / optical path correction
-    correction = @(x,y)(x*OP_p(1)+y*OP_p(2)+x.^2*OP_p(3)+y.^2*OP_p(4)+x.*y*OP_p(5)); %x,y are in microns
-    [xx,zz] = meshgrid(inputScanDimensions.x.values,inputScanDimensions.z.values); %um                
+    % Polynomial is evaluated at (x - xShift_um) to align it with the
+    % physical beam position rather than the commanded galvo position.
+    correction = @(x,y)((x-xShift_um)*OP_p(1)+y*OP_p(2)+(x-xShift_um).^2*OP_p(3)+y.^2*OP_p(4)+(x-xShift_um).*y*OP_p(5)); %x,y are in microns
+    [xx,zz] = meshgrid(inputScanDimensions.x.values,inputScanDimensions.z.values); %um
     scan_min = min(scan(:));
     scan = interp2(xx,zz,scan,xx,zz+correction(xx,inputScanDimensions.y.values(i)),'nearest');
     scan_nan = isnan(scan);

--- a/Processing/yOCTOpticalPathCorrection.m
+++ b/Processing/yOCTOpticalPathCorrection.m
@@ -50,26 +50,14 @@ if strcmpi(inputScanDimensions.x.units, 'na') || ...
 end
 
 %% Extract optical path polynomial from opticalPathCorrectionOptions
-% galvoPhaseDelay_Asamples (N) compensates for the galvo's mechanical lag:
-% the physical beam position lags the commanded position by N A-scan
-% samples. The polynomial is calibrated at calibrationPixelSize_um, so the
-% net shift to apply at runtime is N*(dx - calibrationPixelSize_um).
-calibrationPixelSize_um = 1; % Pixel size used when fitting OpticalPathCorrectionPolynomial
-galvoPhaseDelay_Asamples = 0; % Default: no compensation (backwards compatible)
 if isstruct(opticalPathCorrectionOptions)
     OP_p = opticalPathCorrectionOptions.octProbe.OpticalPathCorrectionPolynomial;
     OP_p = OP_p(:)';
-    if isfield(opticalPathCorrectionOptions.octProbe, 'GalvoPhaseDelay_Asamples')
-        galvoPhaseDelay_Asamples = opticalPathCorrectionOptions.octProbe.GalvoPhaseDelay_Asamples;
-    end
 elseif isstring(opticalPathCorrectionOptions)
     inputVolumeFolder = awsModifyPathForCompetability([opticalPathCorrectionOptions '/']);
     json = awsReadJSON([inputVolumeFolder 'ScanInfo.json']);
     OP_p = json.octProbe.OpticalPathCorrectionPolynomial;
     OP_p = OP_p(:)';
-    if isfield(json.octProbe, 'GalvoPhaseDelay_Asamples')
-        galvoPhaseDelay_Asamples = json.octProbe.GalvoPhaseDelay_Asamples;
-    end
 elseif ismatrix(opticalPathCorrectionOptions)
     if not(isequal(size(opticalPathCorrectionOptions), [1,5])) && not(isequal(size(opticalPathCorrectionOptions), [5,1]))
         error('Optical path correction polynomial must have 5 terms')
@@ -85,26 +73,15 @@ correctedScan = zeros(size(inputScan));
 %% Change dimensions to microns units
 inputScanDimensions = yOCTChangeDimensionsStructureUnits(inputScanDimensions,'microns');
 
-%% Compute galvo lag spatial shift (only along fast x-axis; y-axis is slow)
-xValues_um = inputScanDimensions.x.values;
-if length(xValues_um) > 1
-    dx_um = mean(diff(xValues_um));
-else
-    dx_um = calibrationPixelSize_um;
-end
-xShift_um = galvoPhaseDelay_Asamples * (dx_um - calibrationPixelSize_um);
-
-%% Iterate through the inputScan volume and apply optical path correction to each individual scan
+%% Iterate through the inputScan volume and apply optical path correction to each individual scan 
 for i=1:size(inputScan,3)
-
+    
     % Extract B-scan from volume
     scan = squeeze(inputScan(:,:,i));
-
+    
     %Lens abberation / optical path correction
-    % Polynomial is evaluated at (x - xShift_um) to align it with the
-    % physical beam position rather than the commanded galvo position.
-    correction = @(x,y)((x-xShift_um)*OP_p(1)+y*OP_p(2)+(x-xShift_um).^2*OP_p(3)+y.^2*OP_p(4)+(x-xShift_um).*y*OP_p(5)); %x,y are in microns
-    [xx,zz] = meshgrid(inputScanDimensions.x.values,inputScanDimensions.z.values); %um
+    correction = @(x,y)(x*OP_p(1)+y*OP_p(2)+x.^2*OP_p(3)+y.^2*OP_p(4)+x.*y*OP_p(5)); %x,y are in microns
+    [xx,zz] = meshgrid(inputScanDimensions.x.values,inputScanDimensions.z.values); %um                
     scan_min = min(scan(:));
     scan = interp2(xx,zz,scan,xx,zz+correction(xx,inputScanDimensions.y.values(i)),'nearest');
     scan_nan = isnan(scan);

--- a/Processing/yOCTProcessTiledScan_createDimStructure.m
+++ b/Processing/yOCTProcessTiledScan_createDimStructure.m
@@ -58,6 +58,28 @@ dimOneTile.y.values(end) = [];
 dimOneTile.x.origin = "x=0 is under objective's principal";
 dimOneTile.y.origin = "y=0 is under objective's principal";
 
+%% Correct dimOneTile.x.values for galvo phase delay
+% At low pixel resolutions the galvo's mechanical inertia causes the
+% physical beam to lag the commanded position by N A-scan samples (N is
+% calibrated per probe as GalvoPhaseDelay_Asamples). The OCT records
+% commanded positions, so we rewrite x.values once here, at the single
+% source of truth for tile X coordinates, so that all downstream consumers
+% (optical path correction, tile stitching, surface detection, TIFF
+% metadata) see the corrected positions automatically.
+% Net shift is N*(pixelSize - calibrationPixelSize); zero at calibration
+% pixel size, so this is a no-op for legacy data and for high-resolution
+% scans calibrated at 1 um/pixel.
+calibrationPixelSize_um = 1; % Pixel size at which OpticalPathCorrectionPolynomial was fit
+galvoPhaseDelay_Asamples = 0; % Default: no correction (backwards compatible)
+if isfield(json,'octProbe') && isfield(json.octProbe, 'GalvoPhaseDelay_Asamples')
+    galvoPhaseDelay_Asamples = json.octProbe.GalvoPhaseDelay_Asamples;
+end
+if galvoPhaseDelay_Asamples ~= 0 && isfield(json,'pixelSize_um')
+    xCorrection_mm = galvoPhaseDelay_Asamples * ...
+        (json.pixelSize_um - calibrationPixelSize_um) * 1e-3;
+    dimOneTile.x.values = dimOneTile.x.values - xCorrection_mm;
+end
+
 %% Correct dimOneTile.z to adjust for focus position
 if ~exist('focusPositionInImageZpix','var') || any(isnan(focusPositionInImageZpix))
     % No adjustment because no focus info is provided

--- a/ThorlabsImager/Probe Olympus - 20x - OCTG.ini
+++ b/ThorlabsImager/Probe Olympus - 20x - OCTG.ini
@@ -46,9 +46,10 @@ DefaultDispersionQuadraticTerm = 8.6883e+07
 OpticalPathCorrectionPolynomial = [0.0075237, 0.012723, -0.00015741, -0.00022652, 5.716e-11]
 
 # Galvo phase delay, in number of A-scan samples. Compensates for the
-# galvo's mechanical lag along the fast (x) axis. The actual beam position
-# lags the commanded position by this many samples. Used by yOCTOpticalPathCorrection
-# to evaluate the polynomial at (x - N*(pixelSize - 1um)). If never measured, set to 0 (no compensation).
+# galvo's mechanical lag along the fast (x) axis: the physical beam position
+# lags the commanded position by this many samples. Used to shift x.values by
+# N*(pixelSize_um - 1um) so that downstream consumers see physical positions
+# instead of commanded ones. If never measured, set to 0 (no compensation).
 GalvoPhaseDelay_Asamples = 15.5
 
 ## Apodization

--- a/ThorlabsImager/Probe Olympus - 20x - OCTG.ini
+++ b/ThorlabsImager/Probe Olympus - 20x - OCTG.ini
@@ -45,6 +45,12 @@ DefaultDispersionQuadraticTerm = 8.6883e+07
 # given pixel position x,y correction is to move z by -(p(1)*x + p(2)*y + p(3)*x^2 + p(4)*y^2 + p(5)*x*y)
 OpticalPathCorrectionPolynomial = [0.0075237, 0.012723, -0.00015741, -0.00022652, 5.716e-11]
 
+# Galvo phase delay, in number of A-scan samples. Compensates for the
+# galvo's mechanical lag along the fast (x) axis. The actual beam position
+# lags the commanded position by this many samples. Used by yOCTOpticalPathCorrection
+# to evaluate the polynomial at (x - N*(pixelSize - 1um)). If never measured, set to 0 (no compensation).
+GalvoPhaseDelay_Asamples = 15.5
+
 ## Apodization
 # Position (along x axis) used for apodization, voltage
 ApoVoltage = 10.0


### PR DESCRIPTION
**PROBLEM:** 
At low pixel resolutions (20 um/pixel for exmaple), the galvo mirror's mechanical inertia causes the physical beam position to lag behind the commanded position by a fixed number of A-scan samples. 

Since **yOCTOpticalPathCorrection** evaluates its polynomial at the commanded x-position (calibrated at 1 um/pixel), this lag introduces a systematic spatial offset that scales linearly with pixel size, manifesting as a tilt in corrected B-scans (even ~**100 um** deviation at 20 um/pixel, as shown below). 

<img width="2520" height="479" alt="image" src="https://github.com/user-attachments/assets/a149268f-a080-4570-bb15-5f04d8a51099" />

This makes surface detection and overview scans at low resolution very unreliable.


**SOLUTION:** 
Add a **GalvoPhaseDelay_Asamples** parameter to probe .ini files. 

**yOCTOpticalPathCorrection** now reads this value and shifts the polynomial evaluation point by N x (dx − 1 um) along the fast (x) axis, compensating for the galvo lag at any scan speed. The polynomial is still calibrated at 1 um/pixel; the shift is zero at 1 um/pixel and grows proportionally at coarser resolutions.

In this PR, only the 20x Olympus / OCTG probe has been calibrated (GalvoPhaseDelay_Asamples = 15.5). All other probes are set to 0 (no compensation) until they are individually calibrated. Setting the value to 0 is fully backwards-compatible, no behavior changes for any existing scan.

This fix is a prerequisite for reliable automated tissue surface detection and overview scans when used with the 20x OCTG probe at overview resolutions.

Some low-res scan comparisons with the fix applied and not applied:

XY visual:
<img width="2390" height="421" alt="image" src="https://github.com/user-attachments/assets/3726920d-e5ef-47a4-8355-ad6068703012" />

XZ visual:
<img width="2234" height="94" alt="image" src="https://github.com/user-attachments/assets/c5c59bf6-38e2-48f3-a0ca-333469ecbf7b" />
