### PR TITLE
Fix auto-detected scan range not being a multiple of scan tile size

### DIFF
--- a/Applications/yOCTScanTissueOverview.m
+++ b/Applications/yOCTScanTissueOverview.m
@@ -203,7 +203,7 @@ else
 end
 
 [xTissueRange_mm, yTissueRange_mm, tissueCentroid_mm, tissueArea_mm2] = detectTissueScanRange( ...
-    processedTifPath, overviewZ_um, scanTileSize_mm, temporaryFolder, v);
+    processedTifPath, overviewZ_um, scanTileSize_mm, xRange_mm, yRange_mm, temporaryFolder, v);
 
 end % main function
 
@@ -213,7 +213,7 @@ end % main function
     % tile-aligned scan range that covers it. Also saves two PNGs into
     % temporaryFolder: the raw en-face image and a summary with the accepted range.
     function [xTissueRange_mm, yTissueRange_mm, tissueCentroid_mm, tissueArea_mm2] = detectTissueScanRange( ...
-        processedTifPath, overviewZ_um, scanTileSize_mm, temporaryFolder, v)
+        processedTifPath, overviewZ_um, scanTileSize_mm, xRange_mm, yRange_mm, temporaryFolder, v)
 
     figureVisibility = ternary(v, 'on', 'off');
 
@@ -308,9 +308,11 @@ end % main function
     if ~v, close(hRaw); end
 
     %% Compute tile-aligned scan range, clamped to the overview boundary
-    % Overview boundary comes from the loaded volume itself, not from the caller.
-    overviewXRange_mm = [min(x_mm_row), max(x_mm_row)];
-    overviewYRange_mm = [min(y_mm_col), max(y_mm_col)];
+    % Use the requested scan range as the boundary, not the actual
+    % pixel grid extent. The requested range is always a whole
+    % number of tiles; the pixel grid is not, and clamping to it breaks that.
+    overviewXRange_mm = xRange_mm;
+    overviewYRange_mm = yRange_mm;
 
     CENTROID_ROUND_MM = 0.05;
     cx_r = round(cx_mm / CENTROID_ROUND_MM) * CENTROID_ROUND_MM;

--- a/Applications/yOCTScanTissueOverview.m
+++ b/Applications/yOCTScanTissueOverview.m
@@ -308,9 +308,11 @@ end % main function
     if ~v, close(hRaw); end
 
     %% Compute tile-aligned scan range, clamped to the overview boundary
-    % Use the requested scan range as the boundary, not the actual
-    % pixel grid extent. The requested range is always a whole
-    % number of tiles; the pixel grid is not, and clamping to it breaks that.
+    % The reconstructed pixel grid ends slightly short of the requested range
+    % (e.g. 4.98 instead of 5.0 mm) due to pixel discretization. Clamping to
+    % that pixel extent would break tile alignment, which needs to be multiple of
+    % the FOV. Use the original requested range instead, which is guaranteed 
+    % to be a whole number of tiles:
     overviewXRange_mm = xRange_mm;
     overviewYRange_mm = yRange_mm;
 

--- a/Applications/yOCTScanTissueOverview.m
+++ b/Applications/yOCTScanTissueOverview.m
@@ -308,11 +308,6 @@ end % main function
     if ~v, close(hRaw); end
 
     %% Compute tile-aligned scan range, clamped to the overview boundary
-    % The reconstructed pixel grid ends slightly short of the requested range
-    % (e.g. 4.98 instead of 5.0 mm) due to pixel discretization. Clamping to
-    % that pixel extent would break tile alignment, which needs to be multiple of
-    % the FOV. Use the original requested range instead, which is guaranteed 
-    % to be a whole number of tiles:
     overviewXRange_mm = xRange_mm;
     overviewYRange_mm = yRange_mm;
 


### PR DESCRIPTION
**PROBLEM:**
When migrating from the manual UI adjustment to the fully-automatic detection, the code that kept the returned range aligned to tile size multiples was lost by mistake.

The boundary used to clamp the detected range was changed from the user-requested overview range (e.g. [-5, 5]) to the actual reconstructed pixel extent (e.g. [-5, 4.98]). 

Since the pixel extent is not tile-aligned, the returned scan range ended up with a span like 9.98 mm instead of 10 mm, which yOCTScanTile rejected with: "the size of the scan is not a multiplier of the FOV".

**SOLUTION:**
Clamp the auto-detected range against the user-requested overview range instead of the pixel extent. The requested range is always a whole number of tiles (enforced by yOCTScanTile when the overview itself is scanned), so the returned span is always tile-aligned. This also ensures the full overview area is used when tissue spans to the edge — no coverage is lost.