### PR TITLE
Accept per-depth focusPositionInImageZpix vector to correct focus drift in zStacks

### DIFF
--- a/Processing/yOCTProcessTiledScan.m
+++ b/Processing/yOCTProcessTiledScan.m
@@ -314,6 +314,15 @@ parfor yI=1:length(dimOutput_mm.y.values)
                 % Figure out what is the x,z position of each pixel in this file
                 x = dimFrame.x.values+xCenters(xxI);
                 z = dimFrame.z.values+zDepths(zzI);
+
+                % Correct for focus drift: re-center this tile on its own
+                % focus pixel so that the proper focus lands at absolute
+                % depth zDepths(zzI). For a constant focus (single value), this
+                % is a no-op because dimFrame.z.values is already 0 at the focus.
+                % so behavior is unchanged for the single focus position.
+                if ~isnan(focusPositionInImageZpix(zzI))
+                    z = z - dimFrame.z.values(round(focusPositionInImageZpix(zzI)));
+                end
                 
                 % Helps with interpolation problems
                 x(1) = x(1) - 1e-10; 

--- a/Processing/yOCTProcessTiledScan_createDimStructure.m
+++ b/Processing/yOCTProcessTiledScan_createDimStructure.m
@@ -89,24 +89,19 @@ else
 
     if length(focusPositionInImageZpix) == 1 %#ok<ISCL>
         % Focus position is the same for all scans
-        dimOneTile.z.values = dimOneTile.z.values - dimOneTile.z.values(focusPositionInImageZpix);
+        refFocusPix = focusPositionInImageZpix;
     else
-        % Each scan has a different focus position
-        if std(focusPositionInImageZpix) ~= 0
-            % The situation where each focusPositionInImageZpix has a
-            % differnt zDepth is not implemented yet. The problem is that
-            % for each dimOneTile, z.values are different as they have
-            % different focus correction. This is a problem. 
-            % To solve this, we could return an array of dimOneTile instead
-            % of one dimOneTile, where each dimOneTile corresponds to one
-            % zDepth. But this is a big refactor for yOCTProcessTiledScan.
-            % We are not ready to do that yet.
-            error('This is not implemented yet. See comment above');
-        end
-        
-        dimOneTile.z.values = dimOneTile.z.values - dimOneTile.z.values(focusPositionInImageZpix(1));
+        % Each scan may have a different focus position (focus drift, e.g.
+        % cleared tissue). We anchor z=0 of the template on the focus of the
+        % tile closest to the tissue interface (zDepth ~ 0). The per-tile
+        % focus drift itself is corrected in the main loop of
+        % yOCTProcessTiledScan, where each tile is re-centered on its own
+        % focus value before being placed in the output volume.
+        [~, refTileIndex] = min(abs(json.zDepths));
+        refFocusPix = focusPositionInImageZpix(refTileIndex);
     end
 
+    dimOneTile.z.values = dimOneTile.z.values - dimOneTile.z.values(round(refFocusPix));
     dimOneTile.z.origin = 'z=0 is focus position';
 end
 


### PR DESCRIPTION
**Problem**
When scanning cleared tissue (for example with KK3 clearing agent), the effective refractive index of the medium is higher than the value assumed during reconstruction. This causes the focus to drift deeper into the image as the stage moves down, it is not at a constant pixel position across zDepths as previously assumed:

See example of the problem where focus at 0.4mm drifts dramatically to about 0.8mm in Mitutoyo 10x lens:

<img width="1040" height="453" alt="Screenshot 2026-06-25 at 1 35 11 PM" src="https://github.com/user-attachments/assets/acf84040-f9f6-42ae-afc3-fab7b3352227" />


**yOCTProcessTiledScan** accepted **focusPositionInImageZpix** as a vector (one value per zDepth) but explicitly threw a "**not implemented**" error if the values differed across depths. This forced all zStacks to use a single focus position for every tile, which produces blurred reconstructions in cleared or heterogeneous samples where the focus shifts significantly with depth.


**BEFORE (Same exact scan is used for all reconstruction slides in this example, only processing inputs changed):**
<img width="982" height="585" alt="Screenshot 2026-06-25 at 1 33 45 PM" src="https://github.com/user-attachments/assets/bc940eaf-1b73-478c-ba7b-a26d906ca45b" />


**Solution**
Accept a variable **focusPositionInImageZpix** vector where each entry can differ per z Depth.

Two minimal changes were required:

1. **yOCTProcessTiledScan_createDimStructure**: instead of throwing an error, anchors the template grid at z = 0 using the focus of the tile closest to the tissue surface (z=0). The template defines pixel scale only, which is the same for all tiles regardless of depth.

2. **yOCTProcessTiledScan inner loop**: when placing each tile into the output volume, subtracts the per-depth focus offset from the tile's Z coordinates so that the sharpest region of each tile lands at the correct absolute depth. This is a pure shift, no pixel values are modified, no interpolation artifacts are introduced. No nothing more than using the right portion of each zDepth scanned.

Both changes are backwards-compatible: when **focusPositionInImageZpix** is a constant (all values equal), the correction is a no-op.

**Result**
With the corrected per-depth focus vector, each tile contributes its sharpest region to the correct depth in the final volume. This produces a significantly sharper reconstruction throughout the full z-stack depth. A visual comparison between fixed and variable focus positions on a cleared tissue sample will be added below:

AFTER (Same exact scan is used for all reconstruction slides in this example, only processing inputs changed):

<img width="988" height="585" alt="Screenshot 2026-06-25 at 1 38 54 PM" src="https://github.com/user-attachments/assets/95b8e5f8-055d-454b-8ec4-da63fc995db5" />
