### PR TITLE
Center scan window at acquisition to compensate galvo phase delay

### DIFF
--- a/Processing/test_yOCTProcessTiledScan_createDimStructure.m
+++ b/Processing/test_yOCTProcessTiledScan_createDimStructure.m
@@ -90,37 +90,45 @@ classdef test_yOCTProcessTiledScan_createDimStructure < matlab.unittest.TestCase
             % At low resolution the galvo lag in microns is large. This
             % test uses the real calibrated value for the 20x OCTG probe:
             % N = 15.5 samples at 20 um/pixel => shift = 15.5*(20-1)*1e-3
-            % = 0.2945 mm. It checks three things:
-            %   1. dimOneTile.x.values shifted by exactly 0.2945 mm.
-            %   2. dimOutput.x.values (the full-volume grid) inherited the
-            %      same shift so tile stitching is also correct.
-            %   3. The spacing between adjacent x values did NOT change:
-            %      a constant shift must never affect pixel size.
+            % = 0.2945 mm. New scans are centered at acquisition:
+            % yOCTScanTile moves the commanded center by the shift and
+            % records it in ScanInfo.json, so processing must NOT shift
+            % x.values again. Legacy scans (no correction field in
+            % ScanInfo.json) must still get the old post-processing shift.
 
             pixelSize_um = 20;
             N = 15.5;
             testCase.simulateScan(24, pixelSize_um, N);
             testCase.addTeardown(@() testCase.cleanup());
 
-            [dimOneTile, dimOutput] = yOCTProcessTiledScan_createDimStructure(testCase.TestFolder);
             json = awsReadJSON([testCase.TestFolder 'ScanInfo.json']);
-
             calibrationPixelSize_um = 1;
             expectedShift_mm = N * (pixelSize_um - calibrationPixelSize_um) * 1e-3;
             uncorrected = testCase.uncorrectedXFromJson(json);
-            expected = uncorrected - expectedShift_mm;
 
-            testCase.verifyEqual(dimOneTile.x.values, expected, ...
+            % New scan: correction was applied at acquisition and recorded.
+            testCase.verifyEqual(json.galvoPhaseDelayXOffsetCorrection_mm, expectedShift_mm, ...
                 'AbsTol', 1e-9, ...
-                'Per-tile X must shift by N*(dx-1)*1e-3 mm');
+                'ScanInfo.json must record the acquisition-time correction');
 
-            % Global output X inherits the same shift (single-tile test).
-            testCase.verifyEqual(dimOutput.x.values(1) - uncorrected(1), -expectedShift_mm, ...
+            [dimOneTile, dimOutput] = yOCTProcessTiledScan_createDimStructure(testCase.TestFolder);
+            testCase.verifyEqual(dimOneTile.x.values, uncorrected, ...
                 'AbsTol', 1e-9, ...
-                'Global output X must inherit the correction');
+                'New scans are centered at acquisition, x must not shift');
+            testCase.verifyEqual(dimOutput.x.values(1), uncorrected(1), ...
+                'AbsTol', 1e-9, ...
+                'Global output X must not shift either');
 
-            % Constant subtraction must not change pixel spacing.
-            testCase.verifyEqual(diff(dimOneTile.x.values), diff(uncorrected), ...
+            % Legacy scan: remove the acquisition field, old shift must apply.
+            json = rmfield(json, 'galvoPhaseDelayXOffsetCorrection_mm');
+            awsWriteJSON(json, [testCase.TestFolder 'ScanInfo.json']);
+            [dimOneTileLegacy, ~] = yOCTProcessTiledScan_createDimStructure(testCase.TestFolder);
+            testCase.verifyEqual(dimOneTileLegacy.x.values, uncorrected - expectedShift_mm, ...
+                'AbsTol', 1e-9, ...
+                'Legacy scans must shift by N*(dx-1)*1e-3 mm');
+
+            % Constant shift must not change pixel spacing.
+            testCase.verifyEqual(diff(dimOneTileLegacy.x.values), diff(uncorrected), ...
                 'AbsTol', 1e-12, 'Pixel spacing must be unchanged');
         end
 

--- a/Processing/yOCTProcessTiledScan_createDimStructure.m
+++ b/Processing/yOCTProcessTiledScan_createDimStructure.m
@@ -66,18 +66,20 @@ dimOneTile.y.origin = "y=0 is under objective's principal";
 % source of truth for tile X coordinates, so that all downstream consumers
 % (optical path correction, tile stitching, surface detection, TIFF
 % metadata) see the corrected positions automatically.
-% Net shift is N*(pixelSize - calibrationPixelSize); zero at calibration
-% pixel size, so this is a no-op for legacy data and for high-resolution
-% scans calibrated at 1 um/pixel.
-calibrationPixelSize_um = 1; % Pixel size at which OpticalPathCorrectionPolynomial was fit
-galvoPhaseDelay_Asamples = 0; % Default: no correction (backwards compatible)
-if isfield(json,'octProbe') && isfield(json.octProbe, 'GalvoPhaseDelay_Asamples')
-    galvoPhaseDelay_Asamples = json.octProbe.GalvoPhaseDelay_Asamples;
-end
-if galvoPhaseDelay_Asamples ~= 0 && isfield(json,'pixelSize_um')
-    xCorrection_mm = galvoPhaseDelay_Asamples * ...
-        (json.pixelSize_um - calibrationPixelSize_um) * 1e-3;
-    dimOneTile.x.values = dimOneTile.x.values - xCorrection_mm;
+% Net shift is N*(pixelSize - calibrationPixelSize); zero at 1um/pix.
+% Only runs for old scans: new scans are already centered at acquisition
+% (yOCTScanTile saves galvoPhaseDelayXOffsetCorrection_mm in ScanInfo.json).
+if ~isfield(json, 'galvoPhaseDelayXOffsetCorrection_mm')
+    calibrationPixelSize_um = 1; % Pixel size at which OpticalPathCorrectionPolynomial was fit
+    galvoPhaseDelay_Asamples = 0; % Default: no correction (backwards compatible)
+    if isfield(json,'octProbe') && isfield(json.octProbe, 'GalvoPhaseDelay_Asamples')
+        galvoPhaseDelay_Asamples = json.octProbe.GalvoPhaseDelay_Asamples;
+    end
+    if galvoPhaseDelay_Asamples ~= 0 && isfield(json,'pixelSize_um')
+        xCorrection_mm = galvoPhaseDelay_Asamples * ...
+            (json.pixelSize_um - calibrationPixelSize_um) * 1e-3;
+        dimOneTile.x.values = dimOneTile.x.values - xCorrection_mm;
+    end
 end
 
 %% Correct dimOneTile.z to adjust for focus position

--- a/ThorlabsImager/yOCTScanTile.m
+++ b/ThorlabsImager/yOCTScanTile.m
@@ -126,9 +126,22 @@ end
 [in.xCenters_mm, in.yCenters_mm, in.tileRangeX_mm, in.tileRangeY_mm] = ...
     yOCTScanTile_XYRangeToCenters(in.xRange_mm, in.yRange_mm, in.octProbeFOV_mm);
 
+% Galvo phase delay: the galvo mirror lags behind the commanded position,
+% so the scanned area lands shifted in X. The shift grows with pixel size
+% (N*(pixelSize-1um), zero at the 1um/pix calibration). Move the commanded
+% center by the same amount to cancel it. Saved in ScanInfo.json so
+% processing knows the scan is already centered.
+calibrationPixelSize_um = 1; % Pixel size at which DynamicOffsetX and GalvoPhaseDelay_Asamples were calibrated
+if isfield(in.octProbe, 'GalvoPhaseDelay_Asamples')
+    in.galvoPhaseDelayXOffsetCorrection_mm = in.octProbe.GalvoPhaseDelay_Asamples * ...
+        (in.pixelSize_um - calibrationPixelSize_um) * 1e-3;
+else
+    in.galvoPhaseDelayXOffsetCorrection_mm = 0;
+end
+
 % Check scan is within probe's limits
 if ( ...
-    ((in.xOffset+in.octProbe.DynamicOffsetX + in.tileRangeX_mm*in.octProbe.DynamicFactorX) > in.octProbe.RangeMaxX ) || ...
+    ((in.xOffset+in.octProbe.DynamicOffsetX + in.galvoPhaseDelayXOffsetCorrection_mm + in.tileRangeX_mm*in.octProbe.DynamicFactorX) > in.octProbe.RangeMaxX ) || ...
     ((in.yOffset + in.tileRangeY_mm > in.octProbe.RangeMaxY )) ...
     )
     error('Tring to scan outside lens range');
@@ -187,7 +200,7 @@ end
 mkdir(octFolder);
 
 %% Compute scan centers and ranges
-centerX_mm = in.xOffset + in.octProbe.DynamicOffsetX;
+centerX_mm = in.xOffset + in.octProbe.DynamicOffsetX + in.galvoPhaseDelayXOffsetCorrection_mm;
 centerY_mm = in.yOffset;
 rangeX_mm = in.tileRangeX_mm * in.octProbe.DynamicFactorX;
 rangeY_mm = in.tileRangeY_mm;


### PR DESCRIPTION
**Problem**

At low resolutions (large pixel size) the galvo mirror lags behind the commanded X position, so the physically scanned window lands shifted along the fast axis.

The shift is **GalvoPhaseDelay_Asamples x pixelSize:** invisible at 1 um/pix, but at 20 um/pix (N = 18.77 as example) it is ~375 um - about 1/3 of a tile. 

As a result:

- The optical center (brightest, best-corrected region) appears right of each tile's center instead of centered.
- The left side of every tile is scanned outside the lens's calibrated field, causing vignetting and poor optical path correction (visible residual curvature per tile).
- The existing post-processing X-shift can only relabel coordinates, it cannot recenter what was physically scanned.


**Solution**

Compensate at acquisition time instead of processing time:

- **yOCTScanTile** advances the commanded scan center by **GalvoPhaseDelay_Asamples x (pixelSize - 1um)** (zero at the 1 um/pix calibration anchor, where **DynamicOffsetX** already absorbs the lag), includes the term in the lens range check, and records it in **ScanInfo.json** as **galvoPhaseDelayXOffsetCorrection_mm**.
- **yOCTProcessTiledScan_createDimStructure** skips the legacy post-hoc X shift for scans that carry the new field. Legacy scans (field absent) reprocess exactly as before.

Behavior is unchanged for probes without **GalvoPhaseDelay_Asamples** in their .ini (correction = 0).

Validation:

Before - After
<img width="375" height="330" alt="Screenshot 2026-08-19 at 6 11 37 PM" src="https://github.com/user-attachments/assets/973e4f23-a86b-4377-b120-1fa5c83a33ab" />

<img width="1600" height="850" alt="image" src="https://github.com/user-attachments/assets/feb5bb0f-335d-4386-8d10-bb177e42bc15" />

<img width="1600" height="881" alt="image" src="https://github.com/user-attachments/assets/2b09f19f-afb9-41d4-8d79-e69ed94af6d7" />



