### PR TITLE
Protect existing outputs from accidental overwrite in yOCTProcessTiledScan

### DIFF
--- a/Processing/yOCTProcessTiledScan.m
+++ b/Processing/yOCTProcessTiledScan.m
@@ -93,6 +93,25 @@ if ischar(outputPath)
     outputPath = {outputPath};
 end
 
+% Protect existing outputs from accidental overwrite. If an output already
+% exists, rename the old one to <name>_2 (or _3, ...). The new result is
+% still saved to the requested path (local paths only).
+for i=1:length(outputPath)
+    existingPath = regexprep(outputPath{i}, '[/\\]+$', ''); % drop trailing slash
+    if ~awsIsAWSPath(existingPath) && (exist(existingPath,'file') || exist(existingPath,'dir'))
+        [backupFolder, backupName, backupExt] = fileparts(existingPath);
+        k = 2;
+        backupPath = fullfile(backupFolder, sprintf('%s_%d%s', backupName, k, backupExt));
+        while exist(backupPath,'file') || exist(backupPath,'dir')
+            k = k + 1;
+            backupPath = fullfile(backupFolder, sprintf('%s_%d%s', backupName, k, backupExt));
+        end
+        movefile(existingPath, backupPath);
+        fprintf('%s Output %s already exists, old one renamed to %s\n', ...
+            datestr(datetime), existingPath, backupPath);
+    end
+end
+
 % Set credentials
 if any(cellfun(@(x)(awsIsAWSPath(x)),outputPath))
     % Any of the output folders is on the cloud

--- a/Processing/yOCTProcessTiledScan.m
+++ b/Processing/yOCTProcessTiledScan.m
@@ -94,18 +94,14 @@ if ischar(outputPath)
 end
 
 % Protect existing outputs from accidental overwrite. If an output already
-% exists, rename the old one to <name>_2 (or _3, ...). The new result is
+% exists, rename the old one to <name>_old_<date>. The new result is
 % still saved to the requested path (local paths only).
 for i=1:length(outputPath)
     existingPath = regexprep(outputPath{i}, '[/\\]+$', ''); % drop trailing slash
     if ~awsIsAWSPath(existingPath) && (exist(existingPath,'file') || exist(existingPath,'dir'))
         [backupFolder, backupName, backupExt] = fileparts(existingPath);
-        k = 2;
-        backupPath = fullfile(backupFolder, sprintf('%s_%d%s', backupName, k, backupExt));
-        while exist(backupPath,'file') || exist(backupPath,'dir')
-            k = k + 1;
-            backupPath = fullfile(backupFolder, sprintf('%s_%d%s', backupName, k, backupExt));
-        end
+        backupPath = fullfile(backupFolder, sprintf('%s_old_%s%s', ...
+            backupName, datestr(now,'yyyy-mm-dd_HH-MM-SS'), backupExt));
         movefile(existingPath, backupPath);
         fprintf('%s Output %s already exists, old one renamed to %s\n', ...
             datestr(datetime), existingPath, backupPath);


### PR DESCRIPTION
**Problem:**

yOCTProcessTiledScan deletes the existing output file as soon as processing starts (yOCT2Tif partial file mode init), and the new file only materializes at the end. 

As some people like Komal yesterday have accidentally re-run a script that processes to the same path (like Demo_ScanAndProcess3D) by mistake, the previous reconstruction is destroyed within seconds, including reconstructions that took many hours to build times with no way to recover it.

**Solution**

Before processing starts, if an output path (file or folder) already exists, rename the old one to <name>_old_<date> and print a notice. The new result is still saved to the requested path.